### PR TITLE
Remove generic session type argument from classes

### DIFF
--- a/spec/resource/layout_spec.cr
+++ b/spec/resource/layout_spec.cr
@@ -38,7 +38,7 @@ module Crumble::Resource::LayoutSpec
     it "should print the correct HTML to the HTTP response" do
       res = String.build do |io|
         orig_ctx = Crumble::Server::TestRequestContext.new(response_io: io, resource: MyResource.uri_path)
-        session_store = Crumble::Server::MemorySessionStore(Crumble::Server::Session).new
+        session_store = Crumble::Server::MemorySessionStore.new
         ctx = Crumble::Server::RequestContext.new(session_store, orig_ctx)
         MyResource.handle(ctx)
         ctx.response.flush

--- a/spec/resource/redirect_spec.cr
+++ b/spec/resource/redirect_spec.cr
@@ -11,7 +11,7 @@ module Crumble::Resource::RedirectSpec
 
   context "with a `POST /my` request" do
     orig_ctx = Crumble::Server::TestRequestContext.new(resource: "/crumble/resource/redirect_spec/my", method: "POST")
-    session_store = Crumble::Server::MemorySessionStore(Crumble::Server::Session).new
+    session_store = Crumble::Server::MemorySessionStore.new
     ctx = Crumble::Server::RequestContext.new(session_store, orig_ctx)
     MyResource.handle(ctx)
 

--- a/spec/resource/routing_spec.cr
+++ b/spec/resource/routing_spec.cr
@@ -17,7 +17,7 @@ module Crumble::Resource::RoutingSpec
     it "should call the #index method" do
       res = String.build do |io|
         orig_ctx = Crumble::Server::TestRequestContext.new(response_io: io, resource: "/crumble/resource/routing_spec/my")
-        session_store = Crumble::Server::MemorySessionStore(Crumble::Server::Session).new
+        session_store = Crumble::Server::MemorySessionStore.new
         ctx = Crumble::Server::RequestContext.new(session_store, orig_ctx)
         MyResource.handle(ctx)
         ctx.response.flush
@@ -31,7 +31,7 @@ module Crumble::Resource::RoutingSpec
     it "should call the #show method" do
       res = String.build do |io|
         orig_ctx = Crumble::Server::TestRequestContext.new(response_io: io, resource: "/crumble/resource/routing_spec/my/1")
-        session_store = Crumble::Server::MemorySessionStore(Crumble::Server::Session).new
+        session_store = Crumble::Server::MemorySessionStore.new
         ctx = Crumble::Server::RequestContext.new(session_store, orig_ctx)
         MyResource.handle(ctx)
         ctx.response.flush

--- a/spec/server/memory_session_store_spec.cr
+++ b/spec/server/memory_session_store_spec.cr
@@ -10,7 +10,7 @@ end
 
 describe Crumble::Server::MemorySessionStore do
   it "saves a session and retrieves it again" do
-    store = Crumble::Server::MemorySessionStore(MemorySessionStoreTest::MySession).new
+    store = Crumble::Server::MemorySessionStore.new
     session_key = Crumble::Server::SessionKey.generate
     user_id = 12345
     session = MemorySessionStoreTest::MySession.new(session_key, user_id)

--- a/spec/server/request_context_spec.cr
+++ b/spec/server/request_context_spec.cr
@@ -5,7 +5,7 @@ describe Crumble::Server::RequestContext do
     context "when the request has a cookie with a session key" do
       context "when a session with the key exists" do
         it "returns it" do
-          session_store = Crumble::Server::MemorySessionStore(Crumble::Server::Session).new
+          session_store = Crumble::Server::MemorySessionStore.new
           existing_session_key = Crumble::Server::SessionKey.generate
 
           original_request = HTTP::Request.new("POST", "/dummy", nil, nil)
@@ -22,7 +22,7 @@ describe Crumble::Server::RequestContext do
 
       context "when no session with the key exists in the store" do
         it "returns a new session with a new key" do
-          session_store = Crumble::Server::MemorySessionStore(Crumble::Server::Session).new
+          session_store = Crumble::Server::MemorySessionStore.new
           existing_session_key = Crumble::Server::SessionKey.generate
 
           original_request = HTTP::Request.new("POST", "/dummy", nil, nil)

--- a/spec/test_request_context.cr
+++ b/spec/test_request_context.cr
@@ -1,4 +1,3 @@
-require "../src/server/abstract_request_context"
 require "./test_request"
 require "./test_response"
 

--- a/src/resource/resource.cr
+++ b/src/resource/resource.cr
@@ -1,7 +1,7 @@
 require "./resource_path"
 
 abstract class Resource
-  @ctx : Crumble::Server::AbstractRequestContext
+  @ctx : Crumble::Server::RequestContext
 
   def self.handle(ctx)
     return false if match(ctx.request.path).nil?

--- a/src/server/abstract_request_context.cr
+++ b/src/server/abstract_request_context.cr
@@ -1,5 +1,0 @@
-abstract class Crumble::Server::AbstractRequestContext
-  abstract def request
-  abstract def response
-  abstract def session
-end

--- a/src/server/memory_session_store.cr
+++ b/src/server/memory_session_store.cr
@@ -1,23 +1,23 @@
 require "./session_store"
 
-class Crumble::Server::MemorySessionStore(S)
-  include SessionStore(S)
+class Crumble::Server::MemorySessionStore
+  include SessionStore
 
-  @store : Hash(SessionKey, S)
+  @store : Hash(SessionKey, Crumble::Server::Session)
 
   def initialize
-    @store = {} of SessionKey => S
+    @store = {} of SessionKey => Crumble::Server::Session
   end
 
   def has_key?(key : SessionKey) : Bool
     @store.has_key?(key)
   end
 
-  def [](key : SessionKey) : S
+  def [](key : SessionKey) : Crumble::Server::Session
     @store[key]
   end
 
-  def set(session : S) : Nil
+  def set(session : Crumble::Server::Session) : Nil
     @store[session.id] = session
   end
 end

--- a/src/server/request_context.cr
+++ b/src/server/request_context.cr
@@ -1,9 +1,9 @@
-require "./abstract_request_context"
+require "./session_store"
 
-class Crumble::Server::RequestContext(S) < Crumble::Server::AbstractRequestContext
+class Crumble::Server::RequestContext
   SESSION_COOKIE_NAME = "_crumble_session"
 
-  getter session_store : MemorySessionStore(S)
+  getter session_store : SessionStore
   getter original_context : HTTP::Server::Context
 
   delegate request, response, to: original_context

--- a/src/server/root_request_handler.cr
+++ b/src/server/root_request_handler.cr
@@ -1,7 +1,7 @@
 require "http/server/handler"
 require "./request_context"
 
-class Crumble::Server::RootRequestHandler(S)
+class Crumble::Server::RootRequestHandler
   include HTTP::Handler
 
   REQUEST_HANDLERS = [] of Class.class
@@ -10,7 +10,7 @@ class Crumble::Server::RootRequestHandler(S)
     {% REQUEST_HANDLERS << rh %}
   end
 
-  getter session_store : S
+  getter session_store : SessionStore
 
   def initialize(@session_store)
   end

--- a/src/server/server.cr
+++ b/src/server/server.cr
@@ -25,7 +25,7 @@ module Crumble
         end
       end
 
-      request_handler = RootRequestHandler.new(MemorySessionStore(Crumble::Server::Session).new)
+      request_handler = RootRequestHandler.new(MemorySessionStore.new)
       server = HTTP::Server.new([LogHandler.new(STDOUT), request_handler])
 
       if ENV.fetch("CRUMBLE_ORM_MIGRATION", "").in?(["1", "true"])

--- a/src/server/session_store.cr
+++ b/src/server/session_store.cr
@@ -1,7 +1,7 @@
 require "./session_key"
 
-module Crumble::Server::SessionStore(S)
+module Crumble::Server::SessionStore
   abstract def has_key?(key : SessionKey) : Bool
-  abstract def [](key : SessionKey) : S
-  abstract def set(session : S) : Nil
+  abstract def [](key : SessionKey) : Crumble::Server::Session
+  abstract def set(session : Crumble::Server::Session) : Nil
 end


### PR DESCRIPTION
The Crumble::Server::Session class can be extended directly per project. Not sure what I thought when I added this complexity...