### PR TITLE
Implement `purpose` property for web manifest icons

### DIFF
--- a/spec/web_manifest_spec.cr
+++ b/spec/web_manifest_spec.cr
@@ -1,0 +1,49 @@
+require "./spec_helper"
+require "json"
+
+module WebManifestPurposeSpec
+  AppIcon = PNGFile.new("/icon.png", "fake")
+
+  class SymbolPurposeManifest < Crumble::WebManifest
+    name "Test"
+    short_name "Test"
+
+    icon AppIcon, sizes: "192x192", purpose: :maskable
+  end
+
+  class EnumPurposeManifest < Crumble::WebManifest
+    name "Test"
+    short_name "Test"
+
+    icon AppIcon, sizes: "192x192", purpose: Crumble::WebManifest::IconPurpose::Monochrome
+  end
+
+  class MultiPurposeManifest < Crumble::WebManifest
+    name "Test"
+    short_name "Test"
+
+    icon AppIcon,
+      sizes: "192x192",
+      purpose: {:monochrome, :maskable}
+  end
+end
+
+describe Crumble::WebManifest do
+  it "serializes icon purpose from a symbol" do
+    json = JSON.parse(WebManifestPurposeSpec::SymbolPurposeManifest.to_json)
+    icon = json["icons"].as_a.first
+    icon["purpose"].as_s.should eq("maskable")
+  end
+
+  it "serializes icon purpose from the enum" do
+    json = JSON.parse(WebManifestPurposeSpec::EnumPurposeManifest.to_json)
+    icon = json["icons"].as_a.first
+    icon["purpose"].as_s.should eq("monochrome")
+  end
+
+  it "serializes multiple icon purposes as a space-separated list" do
+    json = JSON.parse(WebManifestPurposeSpec::MultiPurposeManifest.to_json)
+    icon = json["icons"].as_a.first
+    icon["purpose"].as_s.should eq("monochrome maskable")
+  end
+end

--- a/src/pwa_utils.cr
+++ b/src/pwa_utils.cr
@@ -64,7 +64,7 @@ end
 #   # Path must be provided relative to the project directory
 #   Icon = PNGFile.register "icon.png", "assets/icon.png"
 #
-#   icon Icon, sizes: "192x192"
+#   icon Icon, sizes: "192x192", purpose: :maskable
 #
 #   Screenshot = JPGFile.register "screenshot.jpg", "assets/screenshot.jpg"
 #


### PR DESCRIPTION
See https://web.dev/articles/maskable-icon

This is needed when you want to declare your icons as "maskable".