### PR TITLE
CLI init command creates environment.cr

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -58,7 +58,7 @@ class Crumble::CLI
     ensure_dir(RESOURCES_FOLDER)
     ensure_dir(STYLES_FOLDER)
     ensure_dir(PAGES_FOLDER)
-    overwrite_file("#{SRC_FOLDER}/crumble_server.cr", {{read_file "#{__DIR__}/cli/templates/crumble_server.cr"}})
+    overwrite_file("#{SRC_FOLDER}/environment.cr", {{read_file "#{__DIR__}/cli/templates/environment.cr"}})
     if @name
       overwrite_file("#{SRC_FOLDER}/#{@name}.cr", {{read_file "#{__DIR__}/cli/templates/main.cr"}})
     else

--- a/src/cli/templates/environment.cr
+++ b/src/cli/templates/environment.cr
@@ -5,5 +5,3 @@ require "./views/**"
 require "./pages/**"
 require "./resources/**"
 require "./styles/**"
-
-Crumble::Server.start

--- a/src/cli/templates/main.cr
+++ b/src/cli/templates/main.cr
@@ -1,1 +1,3 @@
-require "./crumble_server"
+require "./environment"
+
+Crumble::Server.start


### PR DESCRIPTION
The previous structure didn't allow to only load the project files without starting the server, which didn't work well for specs.