### PR TITLE
Fix method matching in before hook implementations

### DIFF
--- a/spec/page/before_spec.cr
+++ b/spec/page/before_spec.cr
@@ -1,6 +1,13 @@
 require "../spec_helper"
 
+macro add_macro_before
+  before do
+    ctx.request.headers["X-MACRO"]? == "1"
+  end
+end
+
 module Crumble::Page::BeforeSpec
+
   class Parent < Crumble::Page
     before do
       ctx.request.headers["X-OK"]? == "1"
@@ -21,6 +28,20 @@ module Crumble::Page::BeforeSpec
     view do
       template do
         p { "Success!" }
+      end
+    end
+  end
+
+  class MacroBeforePage < Parent
+    add_macro_before
+
+    before do
+      true
+    end
+
+    view do
+      template do
+        p { "Macro Success!" }
       end
     end
   end
@@ -51,6 +72,27 @@ module Crumble::Page::BeforeSpec
       end
 
       res.should contain("Success!")
+    end
+  end
+
+  describe "MacroBeforePage" do
+    it "halts when macro before returns false" do
+      headers = HTTP::Headers{"X-OK" => "1"}
+      ctx = Crumble::Server::TestRequestContext.new(resource: MacroBeforePage.uri_path, headers: headers)
+      MacroBeforePage.handle(ctx).should eq(true)
+      ctx.response.status_code.should eq(400)
+    end
+
+    it "renders when macro before returns true" do
+      res = String.build do |io|
+        headers = HTTP::Headers{"X-OK" => "1", "X-MACRO" => "1"}
+        ctx = Crumble::Server::TestRequestContext.new(response_io: io, resource: MacroBeforePage.uri_path, headers: headers)
+        MacroBeforePage.handle(ctx).should eq(true)
+        ctx.response.status_code.should eq(200)
+        ctx.response.flush
+      end
+
+      res.should contain("Macro Success!")
     end
   end
 end

--- a/src/page/page.cr
+++ b/src/page/page.cr
@@ -11,7 +11,7 @@ abstract class Crumble::Page
   macro before(&blk)
     def _before : Bool | Int32
       {% if @type.has_method?("_before") %}
-        {% if @type.methods.map(&.name).includes?("_before") %}
+        {% if @type.methods.map(&.name.id.stringify).includes?("_before") %}
           prev = previous_def
         {% else %}
           prev = super

--- a/src/resource/resource.cr
+++ b/src/resource/resource.cr
@@ -11,7 +11,7 @@ abstract class Crumble::Resource
     {% for action in actions %}
       def _before_{{action.id}}
         {% if @type.has_method?("_before_#{action.id}") %}
-          {% if @type.methods.map(&.name).includes?("_before_#{action.id}") %}
+          {% if @type.methods.map(&.name.id.stringify).includes?("_before_#{action.id}") %}
             prev = previous_def
           {% else %}
             prev = super


### PR DESCRIPTION
Apparently normal `Def` nodes have a `StringLiteral` name, but those added via a nested macro don't (it's probably a `MacroId` there).