### PR TITLE
Support additional element attributes for form fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,20 @@ end
 `Crumble::Form` lets you define typed form fields, render them as inputs, and parse incoming values from URL-encoded form bodies.
 
 ```crystal
+class ProfileNameController
+  def self.to_html_attrs(_tag, attrs)
+    attrs["data-controller"] = "profile"
+  end
+end
+
+class ProfileNameTarget
+  def self.to_html_attrs(_tag, attrs)
+    attrs["data-controller-target"] = "name"
+  end
+end
+
 class ProfileForm < Crumble::Form
-  field name : String
+  field name : String, attrs: [ProfileNameController, ProfileNameTarget]
   field bio : String?, label: nil
   field slug : String do
     before_render do |value|
@@ -195,7 +207,8 @@ form.valid? # => false if any non-nilable field is nil
 form.values # => {name: "...", bio: nil, slug: "..."}
 ```
 
-- Each `field` supports `type:` and `label:` options for rendering.
+- Each `field` supports `type:`, `label:`, and `attrs:` options for rendering.
+- `attrs:` accepts one or more attribute providers (implementing `to_html_attrs`) to add HTML attributes.
 - Override `default_label_caption(field)` in your form to customize default label text.
 - `before_render` transforms a field value right before rendering its `<input>`.
 - `after_submit` transforms a field value whenever it is assigned (including `from_www_form`).

--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -46,6 +46,25 @@ class Crumble::FormSpec
     end
   end
 
+  class ControllerAttr
+    def self.to_html_attrs(_tag, attrs)
+      attrs["data-controller"] = "signup"
+    end
+  end
+
+  class TargetAttr
+    def self.to_html_attrs(_tag, attrs)
+      attrs["data-controller-target"] = "name"
+    end
+  end
+
+  class AttrForm < Crumble::Form
+    field name : String, attrs: [
+      Crumble::FormSpec::ControllerAttr,
+      Crumble::FormSpec::TargetAttr,
+    ]
+  end
+
   describe "DefaultForm#to_html" do
     it "should return the correct HTML" do
       ctx = test_handler_context
@@ -121,6 +140,18 @@ class Crumble::FormSpec
       form = TransformForm.from_www_form(ctx, URI::Params.encode({name: "  Bob ", code: "  xy "}))
 
       form.values.should eq({name: "Bob", code: "xy"})
+    end
+  end
+
+  describe "AttrForm#to_html" do
+    it "includes additional field attribute objects on the input element" do
+      ctx = test_handler_context
+      expected = <<-HTML.squish
+      <label for="crumble--form-spec--attr-form--name-field-id">Name</label>
+      <input id="crumble--form-spec--attr-form--name-field-id" data-controller="signup" data-controller-target="name" type="text" name="name" value="Bob">
+      HTML
+
+      AttrForm.new(ctx, name: "Bob").to_html.should eq(expected)
     end
   end
 end


### PR DESCRIPTION
You can now provide any objects/classes implementing `#to_html_attrs` (see https://github.com/sbsoftware/to_html.cr) to a `field`  via the `attrs` parameter to add more element attributes when rendering.
I originally wanted the interface to support just positional parameters after the type declaration argument, but Crystal doesn't seem to support that.