### PR TITLE
Mirror page path matching for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ form.values # => {name: "...", bio: nil, slug: "..."}
 
 ### Resources
 
-`Crumble::Resource` gives you RESTful handlers with sensible defaults for `index`, `show`, `create`, `update`, and `destroy`. Routing follows the class name (`CommentsResource` → `/comments`); nested paths are supported one level deep via `self.nested_path`.
+`Crumble::Resource` gives you RESTful handlers with sensible defaults for `index`, `show`, `create`, `update`, and `destroy`. Routing follows the class name (`CommentsResource` → `/comments`); use the same `root_path`, `path_param`, and `nested_path` declarations as pages for custom Resource paths.
 
 ```crystal
 require "css"

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ end
 ```
 
 - `render SomeView` wraps the view in the configured layout and sets `Content-Type` to HTML.
+- Declare path params such as `path_param id` when a Resource should handle member routes; collection paths route to `index`/`create`, and full param paths route to `show`/`update`.
 - `redirect` and `redirect_back` set a `303 See Other` by default.
 - Add `before` filters to short-circuit with `false` (400) or an `Int32` status code.
 

--- a/spec/resource/before_spec.cr
+++ b/spec/resource/before_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 module Crumble::Resource::BeforeSpec
   class Parent < Crumble::Resource
     before do
-      if id?
+      if member?
         true
       else
         false

--- a/spec/resource/before_spec.cr
+++ b/spec/resource/before_spec.cr
@@ -12,6 +12,8 @@ module Crumble::Resource::BeforeSpec
   end
 
   class Res1 < Parent
+    path_param id
+
     before(:show) do
       true
     end
@@ -30,6 +32,8 @@ module Crumble::Resource::BeforeSpec
   end
 
   class Res2 < Parent
+    path_param id
+
     def index
       raise "This should not be reached!"
     end

--- a/spec/resource/path_matching_spec.cr
+++ b/spec/resource/path_matching_spec.cr
@@ -2,9 +2,7 @@ require "../spec_helper"
 
 module Crumble::Resource::PathMatchingSpec
   class RootResource < Resource
-    def self.root_path
-      "/"
-    end
+    root_path "/"
   end
 
   class PageStyleResource < Resource

--- a/spec/resource/path_matching_spec.cr
+++ b/spec/resource/path_matching_spec.cr
@@ -7,6 +7,42 @@ module Crumble::Resource::PathMatchingSpec
     end
   end
 
+  class PageStyleResource < Resource
+    root_path "/accounts"
+    path_param account_id
+    path_param slug, /[a-z0-9-]+/
+    nested_path "posts"
+    nested_path "details"
+
+    def index
+      render "account_id=#{account_id} slug=#{slug}"
+    end
+  end
+
+  class NestedMemberResource < Resource
+    root_path "/nested-members"
+    path_param id
+    nested_path "details"
+
+    def index
+      render "nested id=#{id}"
+    end
+  end
+
+  class LegacyNestedResource < Resource
+    def self.root_path
+      "/legacy-nested"
+    end
+
+    def self.nested_path
+      "/details"
+    end
+
+    def index
+      render "legacy id=#{id}"
+    end
+  end
+
   describe "RootResource.match" do
     it "should match on /" do
       RootResource.match("/").should be_truthy
@@ -14,6 +50,41 @@ module Crumble::Resource::PathMatchingSpec
 
     it "should not match on any other path ending on /" do
       RootResource.match("/test/").should be_falsey
+    end
+  end
+
+  describe "PageStyleResource.match" do
+    it "supports the same path matching declarations as pages" do
+      PageStyleResource.uri_path(account_id: 123, slug: "hello-world").should eq("/accounts/123/hello-world/posts/details")
+      PageStyleResource.match("/accounts/123/hello-world/posts/details").should be_truthy
+      PageStyleResource.match("/accounts/123/hello_world/posts/details").should be_falsey
+    end
+
+    it "exposes declared path params while handling requests" do
+      response = String.build do |io|
+        ctx = Crumble::Server::TestRequestContext.new(response_io: io, resource: PageStyleResource.uri_path(account_id: 123, slug: "hello-world"))
+        PageStyleResource.handle(ctx).should eq(true)
+        ctx.response.flush
+      end
+
+      response.should contain("account_id=123 slug=hello-world")
+    end
+  end
+
+  describe "NestedMemberResource.match" do
+    it "does not match the parent member path without the nested component" do
+      NestedMemberResource.match(NestedMemberResource.uri_path(id: 7)).should be_truthy
+      NestedMemberResource.match("/nested-members/7").should be_falsey
+      NestedMemberResource.match("/nested-members").should be_falsey
+    end
+  end
+
+  describe "LegacyNestedResource.match" do
+    it "does not match the parent collection or member path without the nested component" do
+      LegacyNestedResource.uri_path(7).should eq("/legacy-nested/7/details")
+      LegacyNestedResource.match(LegacyNestedResource.uri_path(7)).should be_truthy
+      LegacyNestedResource.match("/legacy-nested/7").should be_falsey
+      LegacyNestedResource.match("/legacy-nested").should be_falsey
     end
   end
 end

--- a/spec/resource/path_matching_spec.cr
+++ b/spec/resource/path_matching_spec.cr
@@ -13,6 +13,10 @@ module Crumble::Resource::PathMatchingSpec
     nested_path "details"
 
     def index
+      render "accounts index"
+    end
+
+    def show
       render "account_id=#{account_id} slug=#{slug}"
     end
   end
@@ -22,7 +26,7 @@ module Crumble::Resource::PathMatchingSpec
     path_param id
     nested_path "details"
 
-    def index
+    def show
       render "nested id=#{id}"
     end
   end
@@ -35,10 +39,15 @@ module Crumble::Resource::PathMatchingSpec
     it "should not match on any other path ending on /" do
       RootResource.match("/test/").should be_falsey
     end
+
+    it "does not match member paths without declared params" do
+      RootResource.match("/1").should be_falsey
+    end
   end
 
   describe "PageStyleResource.match" do
     it "supports the same path matching declarations as pages" do
+      PageStyleResource.match("/accounts").should be_truthy
       PageStyleResource.uri_path(account_id: 123, slug: "hello-world").should eq("/accounts/123/hello-world/posts/details")
       PageStyleResource.match("/accounts/123/hello-world/posts/details").should be_truthy
       PageStyleResource.match("/accounts/123/hello_world/posts/details").should be_falsey
@@ -57,9 +66,9 @@ module Crumble::Resource::PathMatchingSpec
 
   describe "NestedMemberResource.match" do
     it "does not match the parent member path without the nested component" do
+      NestedMemberResource.match("/nested-members").should be_truthy
       NestedMemberResource.match(NestedMemberResource.uri_path(id: 7)).should be_truthy
       NestedMemberResource.match("/nested-members/7").should be_falsey
-      NestedMemberResource.match("/nested-members").should be_falsey
     end
   end
 end

--- a/spec/resource/path_matching_spec.cr
+++ b/spec/resource/path_matching_spec.cr
@@ -29,20 +29,6 @@ module Crumble::Resource::PathMatchingSpec
     end
   end
 
-  class LegacyNestedResource < Resource
-    def self.root_path
-      "/legacy-nested"
-    end
-
-    def self.nested_path
-      "/details"
-    end
-
-    def index
-      render "legacy id=#{id}"
-    end
-  end
-
   describe "RootResource.match" do
     it "should match on /" do
       RootResource.match("/").should be_truthy
@@ -76,15 +62,6 @@ module Crumble::Resource::PathMatchingSpec
       NestedMemberResource.match(NestedMemberResource.uri_path(id: 7)).should be_truthy
       NestedMemberResource.match("/nested-members/7").should be_falsey
       NestedMemberResource.match("/nested-members").should be_falsey
-    end
-  end
-
-  describe "LegacyNestedResource.match" do
-    it "does not match the parent collection or member path without the nested component" do
-      LegacyNestedResource.uri_path(7).should eq("/legacy-nested/7/details")
-      LegacyNestedResource.match(LegacyNestedResource.uri_path(7)).should be_truthy
-      LegacyNestedResource.match("/legacy-nested/7").should be_falsey
-      LegacyNestedResource.match("/legacy-nested").should be_falsey
     end
   end
 end

--- a/spec/resource/path_matching_spec.cr
+++ b/spec/resource/path_matching_spec.cr
@@ -50,6 +50,7 @@ module Crumble::Resource::PathMatchingSpec
       PageStyleResource.match("/accounts").should be_truthy
       PageStyleResource.uri_path(account_id: 123, slug: "hello-world").should eq("/accounts/123/hello-world/posts/details")
       PageStyleResource.match("/accounts/123/hello-world/posts/details").should be_truthy
+      PageStyleResource.match("/accounts/123").should be_falsey
       PageStyleResource.match("/accounts/123/hello_world/posts/details").should be_falsey
     end
 

--- a/spec/resource/redirect_back_spec.cr
+++ b/spec/resource/redirect_back_spec.cr
@@ -2,9 +2,7 @@ require "../spec_helper"
 
 module Crumble::Resource::RedirectBackSpec
   class HomeResource < Resource
-    def self.root_path
-      "/"
-    end
+    root_path "/"
   end
 
   class MyResource < Resource

--- a/spec/resource/redirect_spec.cr
+++ b/spec/resource/redirect_spec.cr
@@ -2,6 +2,8 @@ require "../spec_helper"
 
 module Crumble::Resource::RedirectSpec
   class MyResource < Resource
+    path_param id
+
     def create
       redirect self.class.uri_path(1)
     end

--- a/spec/resource/routing_spec.cr
+++ b/spec/resource/routing_spec.cr
@@ -2,6 +2,8 @@ require "../spec_helper"
 
 module Crumble::Resource::RoutingSpec
   class MyResource < Resource
+    path_param id
+
     def index
       render "Index!"
     end

--- a/spec/server/request_dispatcher_spec.cr
+++ b/spec/server/request_dispatcher_spec.cr
@@ -42,9 +42,7 @@ end
 
 module Crumble::Server::RequestDispatcherResourceSpec
   class WidgetResource < Crumble::Resource
-    def self.root_path
-      "/root-handler-resource"
-    end
+    root_path "/root-handler-resource"
 
     def index
       ctx.response.print "resource index"
@@ -64,9 +62,7 @@ module Crumble::Server::RequestDispatcherResourceSpec
   end
 
   class SessionResource < Crumble::Resource
-    def self.root_path
-      "/root-handler-session"
-    end
+    root_path "/root-handler-session"
 
     def index
       current = ctx.session.blah || 0

--- a/spec/server/request_dispatcher_spec.cr
+++ b/spec/server/request_dispatcher_spec.cr
@@ -43,6 +43,7 @@ end
 module Crumble::Server::RequestDispatcherResourceSpec
   class WidgetResource < Crumble::Resource
     root_path "/root-handler-resource"
+    path_param id
 
     def index
       ctx.response.print "resource index"

--- a/src/path_matching.cr
+++ b/src/path_matching.cr
@@ -46,14 +46,10 @@ module Crumble::PathMatching
       uri_path_matcher.match(path)
     end
 
-    def self._path_matching_derived_root_path
+    def self._root_path
       suffix = _path_matching_root_suffix
       base_name = suffix.empty? ? self.name : self.name.chomp(suffix)
       "/" + base_name.gsub("::", "/").underscore
-    end
-
-    def self._root_path
-      _path_matching_derived_root_path
     end
 
     def self.uri_path(**params)
@@ -87,20 +83,16 @@ module Crumble::PathMatching
     end
 
     def self.uri_path_matcher
-      segment_patterns = _path_matching_segment_patterns
+      root_segments = _root_path.split('/').reject(&.empty?)
+      segment_patterns = root_segments.map { |seg| Regex.escape(seg) }
+
+      segment_patterns.concat(_path_parts.map(&.segment_pattern))
 
       if segment_patterns.empty?
         /^\/$/
       else
         Regex.new("^/" + segment_patterns.join("/") + "/?$")
       end
-    end
-
-    def self._path_matching_segment_patterns
-      root_segments = _root_path.split('/').reject(&.empty?)
-      segment_patterns = root_segments.map { |seg| Regex.escape(seg) }
-
-      segment_patterns.concat(_path_parts.map(&.segment_pattern))
     end
 
     protected def path_params : Hash(String, String)

--- a/src/path_matching.cr
+++ b/src/path_matching.cr
@@ -46,13 +46,21 @@ module Crumble::PathMatching
       uri_path_matcher.match(path)
     end
 
-    def self._root_path
+    def self._path_matching_derived_root_path
       suffix = _path_matching_root_suffix
       base_name = suffix.empty? ? self.name : self.name.chomp(suffix)
       "/" + base_name.gsub("::", "/").underscore
     end
 
+    def self._root_path
+      _path_matching_derived_root_path
+    end
+
     def self.uri_path(**params)
+      _path_matching_uri_path(**params)
+    end
+
+    def self._path_matching_uri_path(**params)
       param_values = {} of Symbol => String
       params.each do |key, value|
         param_values[key] = value.to_s
@@ -79,16 +87,20 @@ module Crumble::PathMatching
     end
 
     def self.uri_path_matcher
-      root_segments = _root_path.split('/').reject(&.empty?)
-      segment_patterns = root_segments.map { |seg| Regex.escape(seg) }
-
-      segment_patterns.concat(_path_parts.map(&.segment_pattern))
+      segment_patterns = _path_matching_segment_patterns
 
       if segment_patterns.empty?
         /^\/$/
       else
         Regex.new("^/" + segment_patterns.join("/") + "/?$")
       end
+    end
+
+    def self._path_matching_segment_patterns
+      root_segments = _root_path.split('/').reject(&.empty?)
+      segment_patterns = root_segments.map { |seg| Regex.escape(seg) }
+
+      segment_patterns.concat(_path_parts.map(&.segment_pattern))
     end
 
     protected def path_params : Hash(String, String)

--- a/src/resource/resource.cr
+++ b/src/resource/resource.cr
@@ -50,7 +50,7 @@ abstract class Crumble::Resource
 
     case ctx.request.method
     when "GET"
-      if instance.id? && instance.top_level?
+      if instance.member?
         before_action_handling(instance, :show)
         instance.show
       else
@@ -58,7 +58,7 @@ abstract class Crumble::Resource
         instance.index
       end
     when "POST"
-      if instance.id? && instance.top_level?
+      if instance.member?
         before_action_handling(instance, :update)
         instance.update
       else
@@ -74,20 +74,31 @@ abstract class Crumble::Resource
 
   def self.uri_path(id = nil)
     return _root_path unless id
-    return _path_matching_uri_path(id: id) unless _path_parts.empty?
-    root = _root_path.chomp("/")
-    root.empty? ? "/#{id}" : "#{root}/#{id}"
+    raise ArgumentError.new("Cannot build a member path for #{self} without path params") if _path_parts.empty?
+    _path_matching_uri_path(id: id)
   end
 
   def self.uri_path_matcher
-    if _path_parts.empty?
-      root = _root_path.chomp("/")
-      escaped_root = Regex.escape(root)
-      # Plain resources keep REST collection/member routes; the named capture feeds #id? through PathMatching#path_params.
-      root.empty? ? /^\/(?:(?<id>\d+)\/?)?$/ : Regex.new("^#{escaped_root}(?:/(?<id>\\d+))?/?$")
+    if path_param?
+      collection_pattern = _root_path_segment_patterns.empty? ? "/" : "/" + _root_path_segment_patterns.join("/")
+      member_pattern = "/" + (_root_path_segment_patterns + _path_parts.map(&.segment_pattern)).join("/")
+
+      if collection_pattern == "/"
+        Regex.new("^(?:/|#{member_pattern}/?)$")
+      else
+        Regex.new("^(?:#{collection_pattern}|#{member_pattern})/?$")
+      end
     else
       previous_def
     end
+  end
+
+  def self.path_param?
+    _path_parts.any? { |part| part.is_a?(Crumble::PathMatching::ParamPathPart) }
+  end
+
+  def self._root_path_segment_patterns
+    _root_path.split('/').reject(&.empty?).map { |seg| Regex.escape(seg) }
   end
 
   def initialize(@request_ctx); end
@@ -182,6 +193,10 @@ abstract class Crumble::Resource
 
   def id
     id?.not_nil!
+  end
+
+  def member?
+    path_params.size > 0
   end
 
   def nested?

--- a/src/resource/resource.cr
+++ b/src/resource/resource.cr
@@ -94,8 +94,17 @@ abstract class Crumble::Resource
     end
   end
 
+  @[Deprecated("Use nested_path \"...\" declarations instead.")]
   def self.nested_path
     ""
+  end
+
+  def self._legacy_nested_path
+    {% if @type.class.methods.map(&.name.stringify).includes?("nested_path") %}
+      nested_path
+    {% else %}
+      ""
+    {% end %}
   end
 
   macro nested_path(path)
@@ -105,7 +114,7 @@ abstract class Crumble::Resource
   def self.uri_path(id = nil)
     return root_path unless id
     return _path_matching_uri_path(id: id) unless _path_parts.empty?
-    "#{root_path}/#{id}#{nested_path}"
+    "#{root_path}/#{id}#{_legacy_nested_path}"
   end
 
   def self.uri_path(**params)
@@ -117,11 +126,14 @@ abstract class Crumble::Resource
       root = root_path.chomp("/")
       escaped_root = Regex.escape(root)
 
-      if nested_path.empty?
+      legacy_nested_path = _legacy_nested_path
+
+      if legacy_nested_path.empty?
         root.empty? ? /^\/(?:(?<id>\d+)\/?)?$/ : Regex.new("^#{escaped_root}(?:/(?<id>\\d+))?/?$")
       else
         # A nested resource path belongs to the nested endpoint only; the parent collection/member path must stay available to its own resource.
-        root.empty? ? Regex.new("^/(?<id>\\d+)#{Regex.escape(nested_path)}/?$") : Regex.new("^#{escaped_root}/(?<id>\\d+)#{Regex.escape(nested_path)}/?$")
+        escaped_nested_path = Regex.escape(legacy_nested_path)
+        root.empty? ? Regex.new("^/(?<id>\\d+)#{escaped_nested_path}/?$") : Regex.new("^#{escaped_root}/(?<id>\\d+)#{escaped_nested_path}/?$")
       end
     else
       previous_def
@@ -227,7 +239,7 @@ abstract class Crumble::Resource
       return self.class._path_parts.any? { |part| part.is_a?(Crumble::PathMatching::NestedPathPart) }
     end
 
-    self.class.nested_path.size > 0
+    self.class._legacy_nested_path.size > 0
   end
 
   def top_level?

--- a/src/resource/resource.cr
+++ b/src/resource/resource.cr
@@ -94,19 +94,6 @@ abstract class Crumble::Resource
     end
   end
 
-  @[Deprecated("Use nested_path \"...\" declarations instead.")]
-  def self.nested_path
-    ""
-  end
-
-  def self._legacy_nested_path
-    {% if @type.class.methods.map(&.name.stringify).includes?("nested_path") %}
-      nested_path
-    {% else %}
-      ""
-    {% end %}
-  end
-
   macro nested_path(path)
     PATH_PARTS << Crumble::PathMatching::NestedPathPart.new({{path}})
   end
@@ -114,7 +101,7 @@ abstract class Crumble::Resource
   def self.uri_path(id = nil)
     return root_path unless id
     return _path_matching_uri_path(id: id) unless _path_parts.empty?
-    "#{root_path}/#{id}#{_legacy_nested_path}"
+    "#{root_path}/#{id}"
   end
 
   def self.uri_path(**params)
@@ -125,16 +112,7 @@ abstract class Crumble::Resource
     if _path_parts.empty?
       root = root_path.chomp("/")
       escaped_root = Regex.escape(root)
-
-      legacy_nested_path = _legacy_nested_path
-
-      if legacy_nested_path.empty?
-        root.empty? ? /^\/(?:(?<id>\d+)\/?)?$/ : Regex.new("^#{escaped_root}(?:/(?<id>\\d+))?/?$")
-      else
-        # A nested resource path belongs to the nested endpoint only; the parent collection/member path must stay available to its own resource.
-        escaped_nested_path = Regex.escape(legacy_nested_path)
-        root.empty? ? Regex.new("^/(?<id>\\d+)#{escaped_nested_path}/?$") : Regex.new("^#{escaped_root}/(?<id>\\d+)#{escaped_nested_path}/?$")
-      end
+      root.empty? ? /^\/(?:(?<id>\d+)\/?)?$/ : Regex.new("^#{escaped_root}(?:/(?<id>\\d+))?/?$")
     else
       previous_def
     end
@@ -239,7 +217,7 @@ abstract class Crumble::Resource
       return self.class._path_parts.any? { |part| part.is_a?(Crumble::PathMatching::NestedPathPart) }
     end
 
-    self.class._legacy_nested_path.size > 0
+    false
   end
 
   def top_level?

--- a/src/resource/resource.cr
+++ b/src/resource/resource.cr
@@ -72,41 +72,16 @@ abstract class Crumble::Resource
     return true
   end
 
-  def self.root_path
-    _root_path
-  end
-
-  def self.root_path(id)
-    "#{root_path}/#{id}"
-  end
-
-  macro root_path(path)
-    def self._root_path
-      {{path}}
-    end
-
-    def self.root_path
-      {{path}}
-    end
-  end
-
-  macro nested_path(path)
-    PATH_PARTS << Crumble::PathMatching::NestedPathPart.new({{path}})
-  end
-
   def self.uri_path(id = nil)
-    return root_path unless id
+    return _root_path unless id
     return _path_matching_uri_path(id: id) unless _path_parts.empty?
-    "#{root_path}/#{id}"
-  end
-
-  def self.uri_path(**params)
-    _path_matching_uri_path(**params)
+    root = _root_path.chomp("/")
+    root.empty? ? "/#{id}" : "#{root}/#{id}"
   end
 
   def self.uri_path_matcher
     if _path_parts.empty?
-      root = root_path.chomp("/")
+      root = _root_path.chomp("/")
       escaped_root = Regex.escape(root)
       root.empty? ? /^\/(?:(?<id>\d+)\/?)?$/ : Regex.new("^#{escaped_root}(?:/(?<id>\\d+))?/?$")
     else

--- a/src/resource/resource.cr
+++ b/src/resource/resource.cr
@@ -77,7 +77,7 @@ abstract class Crumble::Resource
   end
 
   def self.root_path
-    _path_matching_derived_root_path
+    "/" + self.name.chomp("Resource").gsub("::", "/").underscore
   end
 
   def self.root_path(id)
@@ -213,11 +213,7 @@ abstract class Crumble::Resource
   end
 
   def nested?
-    unless self.class._path_parts.empty?
-      return self.class._path_parts.any? { |part| part.is_a?(Crumble::PathMatching::NestedPathPart) }
-    end
-
-    false
+    self.class._path_parts.any? { |part| part.is_a?(Crumble::PathMatching::NestedPathPart) }
   end
 
   def top_level?

--- a/src/resource/resource.cr
+++ b/src/resource/resource.cr
@@ -187,14 +187,6 @@ abstract class Crumble::Resource
     ctx.response.print "Not Found"
   end
 
-  def id?
-    path_params["id"]?.try(&.to_i64?)
-  end
-
-  def id
-    id?.not_nil!
-  end
-
   def member?
     path_params.size > 0
   end

--- a/src/resource/resource.cr
+++ b/src/resource/resource.cr
@@ -83,6 +83,7 @@ abstract class Crumble::Resource
     if _path_parts.empty?
       root = _root_path.chomp("/")
       escaped_root = Regex.escape(root)
+      # Plain resources keep REST collection/member routes; the named capture feeds #id? through PathMatching#path_params.
       root.empty? ? /^\/(?:(?<id>\d+)\/?)?$/ : Regex.new("^#{escaped_root}(?:/(?<id>\\d+))?/?$")
     else
       previous_def

--- a/src/resource/resource.cr
+++ b/src/resource/resource.cr
@@ -1,7 +1,17 @@
 require "../server/view_handler"
+require "../path_matching"
 
 abstract class Crumble::Resource
   include Crumble::Server::ViewHandler
+  include Crumble::PathMatching
+
+  def self._path_matching_root_suffix : String
+    "Resource"
+  end
+
+  def self._root_path
+    root_path
+  end
 
   macro before(&blk)
     before(:index, :create, :show, :update, :destroy) {{blk}}
@@ -66,36 +76,55 @@ abstract class Crumble::Resource
     return true
   end
 
-  def self.match(path)
-    uri_path_matcher.match(path)
-  end
-
   def self.root_path
-    "/" + self.name.chomp("Resource").gsub("::", "/").underscore
+    _path_matching_derived_root_path
   end
 
   def self.root_path(id)
     "#{root_path}/#{id}"
   end
 
+  macro root_path(path)
+    def self._root_path
+      {{path}}
+    end
+
+    def self.root_path
+      {{path}}
+    end
+  end
+
   def self.nested_path
     ""
   end
 
+  macro nested_path(path)
+    PATH_PARTS << Crumble::PathMatching::NestedPathPart.new({{path}})
+  end
+
   def self.uri_path(id = nil)
-    path = root_path
-    if id
-      path += "/#{id}"
-      path += nested_path
-    end
-    path
+    return root_path unless id
+    return _path_matching_uri_path(id: id) unless _path_parts.empty?
+    "#{root_path}/#{id}#{nested_path}"
+  end
+
+  def self.uri_path(**params)
+    _path_matching_uri_path(**params)
   end
 
   def self.uri_path_matcher
-    if nested_path.empty?
-      /^#{root_path}(\/|\/(\d+))?$/
+    if _path_parts.empty?
+      root = root_path.chomp("/")
+      escaped_root = Regex.escape(root)
+
+      if nested_path.empty?
+        root.empty? ? /^\/(?:(?<id>\d+)\/?)?$/ : Regex.new("^#{escaped_root}(?:/(?<id>\\d+))?/?$")
+      else
+        # A nested resource path belongs to the nested endpoint only; the parent collection/member path must stay available to its own resource.
+        root.empty? ? Regex.new("^/(?<id>\\d+)#{Regex.escape(nested_path)}/?$") : Regex.new("^#{escaped_root}/(?<id>\\d+)#{Regex.escape(nested_path)}/?$")
+      end
     else
-      /^#{root_path}(\/|\/(\d+)(#{nested_path})?)?$/
+      previous_def
     end
   end
 
@@ -186,7 +215,7 @@ abstract class Crumble::Resource
   end
 
   def id?
-    self.class.match(ctx.request.path).try { |m| m[2]?.try(&.to_i64) }
+    path_params["id"]?.try(&.to_i64?)
   end
 
   def id
@@ -194,6 +223,10 @@ abstract class Crumble::Resource
   end
 
   def nested?
+    unless self.class._path_parts.empty?
+      return self.class._path_parts.any? { |part| part.is_a?(Crumble::PathMatching::NestedPathPart) }
+    end
+
     self.class.nested_path.size > 0
   end
 

--- a/src/resource/resource.cr
+++ b/src/resource/resource.cr
@@ -9,10 +9,6 @@ abstract class Crumble::Resource
     "Resource"
   end
 
-  def self._root_path
-    root_path
-  end
-
   macro before(&blk)
     before(:index, :create, :show, :update, :destroy) {{blk}}
   end
@@ -77,7 +73,7 @@ abstract class Crumble::Resource
   end
 
   def self.root_path
-    "/" + self.name.chomp("Resource").gsub("::", "/").underscore
+    _root_path
   end
 
   def self.root_path(id)


### PR DESCRIPTION
## Summary
- Share Page path matching helpers with Resources
- Add Resource support for `root_path`, `path_param`, `nested_path`, and named `uri_path`
- Prevent nested Resource paths from matching parent-only collection or member paths

## Testing
- `CRYSTAL_CACHE_DIR=/tmp/crystal-cache- crystal spec --error-trace`