### PR TITLE
Add OpenTelemetry HTTP server span attributes

### DIFF
--- a/spec/server/open_telemetry_handler_spec.cr
+++ b/spec/server/open_telemetry_handler_spec.cr
@@ -1,0 +1,50 @@
+require "../spec_helper"
+require "json"
+
+describe Crumble::Server::OpenTelemetryHandler do
+  it "sets OpenTelemetry HTTP server span attributes" do
+    memory = IO::Memory.new
+    previous_config = OpenTelemetry.config
+    request = Crumble::Server::TestRequest.new(resource: "/widgets/123/edit?tab=details", method: "POST", remote_address: "203.0.113.8", headers: HTTP::Headers{"Host" => "example.test:8443", "User-Agent" => "crumble-spec/1.0", "X-Forwarded-Proto" => "https"})
+    request.local_address = Socket::IPAddress.new("10.0.0.10", 8080)
+    context = HTTP::Server::Context.new(request, Crumble::Server::TestResponse.new)
+    handler = Crumble::Server::OpenTelemetryHandler.new
+    handler.next = ->(ctx : HTTP::Server::Context) { ctx.response.status_code = 204; nil }
+
+    begin
+      OpenTelemetry.configure do |config|
+        config.exporter = OpenTelemetry::Exporter.new(variant: :io, io: memory)
+      end
+
+      handler.call(context)
+      10.times do
+        break if memory.size > 0
+        sleep 10.milliseconds
+      end
+
+      memory.rewind
+      span = JSON.parse(memory.gets_to_end)["spans"][0]
+      attributes = span["attributes"]
+
+      span["name"].as_s.should eq("POST /widgets/:id/edit")
+      attributes["deployment.environment.name"].as_s.should eq(ENV.fetch("CRUMBLE_ENV", "dev"))
+      attributes["http.request.method"].as_s.should eq("POST")
+      attributes["http.route"].as_s.should eq("/widgets/:id/edit")
+      attributes["url.path"].as_s.should eq("/widgets/123/edit")
+      attributes["url.scheme"].as_s.should eq("https")
+      attributes["server.address"].as_s.should eq("example.test")
+      attributes["server.port"].as_i.should eq(8443)
+      attributes["network.protocol.name"].as_s.should eq("http")
+      attributes["network.protocol.version"].as_s.should eq("1.1")
+      attributes["user_agent.original"].as_s.should eq("crumble-spec/1.0")
+      attributes["client.address"].as_s.should eq("203.0.113.8")
+      attributes["http.response.status_code"].as_i.should eq(204)
+      attributes.as_h.has_key?("http.method").should be_false
+      attributes.as_h.has_key?("http.path").should be_false
+      attributes.as_h.has_key?("http.status_code").should be_false
+    ensure
+      OpenTelemetry.config = previous_config
+      OpenTelemetry.provider.configure!(previous_config)
+    end
+  end
+end

--- a/src/server/open_telemetry_handler.cr
+++ b/src/server/open_telemetry_handler.cr
@@ -1,5 +1,6 @@
 require "http/server/handler"
 require "opentelemetry-sdk"
+require "uri"
 
 module Crumble::Server
   class OpenTelemetryHandler
@@ -13,15 +14,56 @@ module Crumble::Server
         span.server!
 
         span["deployment.environment.name"] = ENV.fetch("CRUMBLE_ENV", "dev")
-        span["http.method"] = context.request.method
-        span["http.path"] = context.request.path
+        span["http.request.method"] = context.request.method
+        span["http.route"] = generic_path
+        span["url.path"] = context.request.path
+        span["url.scheme"] = url_scheme(context.request)
+        span["server.address"] = server_address(context.request)
+        span["server.port"] = server_port(context.request).to_i64
+        span["network.protocol.name"] = "http"
+        span["network.protocol.version"] = context.request.version.starts_with?("HTTP/") ? context.request.version[5..] : context.request.version
+        span["user_agent.original"] = context.request.headers["User-Agent"] if context.request.headers.has_key?("User-Agent")
+        span["client.address"] = client_address(context.request) if context.request.remote_address
 
         begin
           call_next(context)
         ensure
-          span["http.status_code"] = context.response.status_code.to_i64
+          span["http.response.status_code"] = context.response.status_code.to_i64
         end
       end
+    end
+
+    private def url_scheme(request)
+      request.headers["X-Forwarded-Proto"]?.try(&.split(",").first.strip) || configured_host_uri.try(&.scheme) || "http"
+    end
+
+    private def server_address(request)
+      request.hostname || configured_host_uri.try(&.hostname) || "localhost"
+    end
+
+    private def server_port(request)
+      request_host_uri(request).try(&.port) || request.local_address.try { |address| address.as?(Socket::IPAddress).try(&.port) } || configured_host_uri.try(&.port) || Crumble::Server.port
+    end
+
+    private def client_address(request)
+      case remote_address = request.remote_address
+      when Socket::IPAddress
+        remote_address.address
+      else
+        remote_address.to_s
+      end
+    end
+
+    private def request_host_uri(request)
+      URI.parse("http://#{request.headers["Host"]}") if request.headers.has_key?("Host")
+    rescue URI::Error
+      nil
+    end
+
+    private def configured_host_uri
+      URI.parse(Crumble::Server.host)
+    rescue URI::Error
+      nil
     end
   end
 end


### PR DESCRIPTION
## Summary
- Rename HTTP span attributes to OpenTelemetry semantic convention names
- Add HTTP server span attributes for route, scheme, server, network protocol, user agent, and client address
- Add coverage for exported span attributes

## Tests
- `crystal spec`