### PR TITLE
Add session reload API

### DIFF
--- a/spec/server/session_decorator_reload_spec.cr
+++ b/spec/server/session_decorator_reload_spec.cr
@@ -1,0 +1,36 @@
+require "../spec_helper"
+require "file_utils"
+
+module Crumble::Server::SessionDecoratorReloadSpec
+  describe "SessionDecorator#reload" do
+    it "reloads a memoized request context session from memory storage" do
+      store = MemorySessionStore.new
+      context = TestRequestContext.new(session_store: store)
+      context.session.update!(blah: 1)
+      updated_session = ::Crumble::Server::Session.new(context.session.id)
+      updated_session.update!(blah: 2)
+      store.set(updated_session)
+
+      context.session.blah.should eq(1)
+      context.session.reload.should be(context.session)
+      context.session.blah.should eq(2)
+      context.session.session.should be(updated_session)
+    end
+
+    it "reloads a memoized request context session from file storage" do
+      FileUtils.mkdir_p("/tmp/crumble-session-decorator-reload")
+      store = FileSessionStore.new("/tmp/crumble-session-decorator-reload")
+      context = TestRequestContext.new(session_store: store)
+      context.session.update!(blah: 1)
+      updated_session = ::Crumble::Server::Session.new(context.session.id)
+      updated_session.update!(blah: 2)
+      store.set(updated_session)
+
+      context.session.blah.should eq(1)
+      context.session.reload.should be(context.session)
+      context.session.blah.should eq(2)
+    ensure
+      FileUtils.rm_rf("/tmp/crumble-session-decorator-reload")
+    end
+  end
+end

--- a/spec/test_request_context.cr
+++ b/spec/test_request_context.cr
@@ -2,6 +2,8 @@ require "./test_request"
 require "./test_response"
 
 class Crumble::Server::TestRequestContext < Crumble::Server::RequestContext
+  @session_store : SessionStore
+
   def initialize(response_io = nil, session_store = nil, **request_args)
     request = TestRequest.new(**request_args)
     response = TestResponse.new(response_io)

--- a/src/server/session_decorator.cr
+++ b/src/server/session_decorator.cr
@@ -14,4 +14,12 @@ class Crumble::Server::SessionDecorator
 
     session_store.set(session)
   end
+
+  # Replaces the wrapped session with the latest version from the store and returns this decorator.
+  # This keeps the current session id; if the store no longer has that session, the store lookup raises.
+  def reload
+    @session = session_store[session.id]
+
+    self
+  end
 end


### PR DESCRIPTION
## Summary
- Add `SessionDecorator#reload` to refresh the wrapped session from the current session store.
- Document reload behavior in the public API comment.
- Cover memoized request context reloads for memory and file-backed session stores.

## Testing
- `crystal spec spec/server/session_decorator_reload_spec.cr`
- `crystal spec`