### PR TITLE
Add fresh form factory API

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,16 @@ end
 form = ProfileForm.from_www_form(ctx, ctx.request.body.try(&.gets_to_end) || "")
 form.valid? # => false if any non-nilable field is nil
 form.values # => {name: "...", bio: nil, slug: "..."}
+fresh_form = form.fresh # => a new unsubmitted ProfileForm for the same context
 ```
 
 - Each `field` supports `type:`, `label:`, and `attrs:` options for rendering.
 - `attrs:` accepts attribute providers (implementing `to_html_attrs`), a named tuple of HTML attributes, or a mix of both.
+- Use `field name : String = "Alice"` to set the fresh form's default field value.
 - Override `default_label_caption(field)` in your form to customize default label text.
 - `before_render` transforms a field value right before rendering its `<input>`.
 - `after_submit` transforms a field value whenever it is assigned (including `from_www_form`).
+- `fresh(ctx)` and `form.fresh` create a fresh unsubmitted form from normal defaults without parsing request data.
 
 ### Resources
 

--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -59,6 +59,28 @@ class Crumble::FormSpec
     end
   end
 
+  class FreshForm < Crumble::Form
+    field name : String = " Alice " do
+      before_render do |value|
+        value.upcase
+      end
+
+      after_submit do |value|
+        value.strip
+      end
+    end
+
+    field code : String? = " xy " do
+      before_render do |value|
+        value.try(&.upcase)
+      end
+
+      after_submit do |value|
+        value.try(&.strip)
+      end
+    end
+  end
+
   class AllowBlankForm < Crumble::Form
     field name : String, allow_blank: false do
       after_submit do |value|
@@ -219,6 +241,28 @@ class Crumble::FormSpec
       form = TransformForm.from_www_form(ctx, URI::Params.encode({name: "  Bob ", code: "  xy "}))
 
       form.values.should eq({name: "Bob", code: "xy"})
+    end
+  end
+
+  describe "FreshForm" do
+    it "builds a fresh unsubmitted form with field defaults" do
+      ctx = test_handler_context
+      form = FreshForm.fresh(ctx)
+
+      form.submitted?.should be_false
+      form.values.should eq({name: " Alice ", code: " xy "})
+      form.to_html.should contain(%(name="name" value=" ALICE "))
+      form.to_html.should contain(%(name="code" value=" XY "))
+    end
+
+    it "builds a fresh form for the same context from a submitted instance" do
+      ctx = test_handler_context
+      submitted = FreshForm.from_www_form(ctx, URI::Params.encode({name: "  Bob ", code: "  zz "}))
+      fresh = submitted.fresh
+
+      fresh.ctx.request_context.should be(ctx.request_context)
+      fresh.submitted?.should be_false
+      fresh.values.should eq({name: " Alice ", code: " xy "})
     end
   end
 

--- a/src/form.cr
+++ b/src/form.cr
@@ -39,6 +39,17 @@ module Crumble
       @submitted
     end
 
+    # Builds a fresh, unsubmitted form for `ctx` without reading request data.
+    # Defaults come from the form's normal initializer, matching its initial render state.
+    def self.fresh(ctx : Crumble::Server::HandlerContext) : self
+      new(ctx)
+    end
+
+    # Builds a fresh, unsubmitted form for the same context without reading request data.
+    def fresh
+      self.class.fresh(ctx)
+    end
+
     def errors : Array(String)?
       @errors.try(&.map(&.[1]))
     end
@@ -235,7 +246,11 @@ module Crumble
         @[Nilable]
       {% end %}
 
-      getter {{field_name}} : {{field_type}}?
+      {% if type_decl.value %}
+        getter {{field_name}} : {{field_type}}? = {{type_decl.value}}
+      {% else %}
+        getter {{field_name}} : {{field_type}}?
+      {% end %}
 
       css_id {{field_name.id.stringify.camelcase.id}}FieldId
     end


### PR DESCRIPTION
## Summary
- Add class and instance `fresh` APIs for building unsubmitted forms without reading request data
- Preserve field defaults declared with `field name : Type = default`
- Document fresh forms and default field values in the README

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/crumble-crystal-cache crystal spec`