### PR TITLE
Add fresh form factory API

### DIFF
--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -72,6 +72,18 @@ class Crumble::FormSpec
     end
   end
 
+  class TransformedDefaultValueForm < Crumble::Form
+    field name : String = "  default name  " do
+      before_render do |value|
+        value.upcase
+      end
+
+      after_submit do |value|
+        value.strip
+      end
+    end
+  end
+
   class AllowBlankForm < Crumble::Form
     field name : String, allow_blank: false do
       after_submit do |value|
@@ -264,6 +276,43 @@ class Crumble::FormSpec
       }))
 
       form.values.should eq({access_token: "submitted-token", name: "Submitted name"})
+    end
+  end
+
+  describe ".fresh" do
+    it "builds an unsubmitted form with declared defaults" do
+      ctx = test_handler_context
+      form = DefaultValueForm.fresh(ctx)
+
+      form.ctx.should eq(ctx)
+      form.submitted?.should be_false
+      form.values.should eq({access_token: "default-token", name: "  Default name  "})
+    end
+
+    it "does not read or parse the request body" do
+      ctx = test_handler_context(method: "POST", body: URI::Params.encode({name: "Body value"}))
+      form = DefaultValueForm.fresh(ctx)
+
+      form.values.should eq({access_token: "default-token", name: "  Default name  "})
+      ctx.request.body.try(&.gets_to_end).should eq("name=Body+value")
+    end
+
+    it "preserves defaults for transformed fields" do
+      ctx = test_handler_context
+      submitted_form = TransformedDefaultValueForm.from_www_form(ctx, URI::Params.encode({name: "  Submitted name  "}))
+      fresh_form = submitted_form.fresh
+      expected = <<-HTML.squish
+      <div class="crumble--field">
+        <label for="crumble--form-spec--transformed-default-value-form--name-field-id">Name</label>
+        <input id="crumble--form-spec--transformed-default-value-form--name-field-id" type="text" name="name" value="  DEFAULT NAME  ">
+      </div>
+      HTML
+
+      submitted_form.values.should eq({name: "Submitted name"})
+      fresh_form.ctx.should eq(ctx)
+      fresh_form.submitted?.should be_false
+      fresh_form.values.should eq({name: "  default name  "})
+      fresh_form.to_html.should eq(expected)
     end
   end
 

--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -279,10 +279,14 @@ class Crumble::FormSpec
     end
   end
 
-  describe ".fresh" do
+  describe "#fresh" do
     it "builds an unsubmitted form with declared defaults" do
       ctx = test_handler_context
-      form = DefaultValueForm.fresh(ctx)
+      submitted_form = DefaultValueForm.from_www_form(ctx, URI::Params.encode({
+        access_token: "submitted-token",
+        name:         "Submitted name",
+      }))
+      form = submitted_form.fresh
 
       form.ctx.should eq(ctx)
       form.submitted?.should be_false
@@ -291,7 +295,11 @@ class Crumble::FormSpec
 
     it "does not read or parse the request body" do
       ctx = test_handler_context(method: "POST", body: URI::Params.encode({name: "Body value"}))
-      form = DefaultValueForm.fresh(ctx)
+      submitted_form = DefaultValueForm.from_www_form(ctx, URI::Params.encode({
+        access_token: "submitted-token",
+        name:         "Submitted name",
+      }))
+      form = submitted_form.fresh
 
       form.values.should eq({access_token: "default-token", name: "  Default name  "})
       ctx.request.body.try(&.gets_to_end).should eq("name=Body+value")

--- a/src/form.cr
+++ b/src/form.cr
@@ -53,6 +53,17 @@ module Crumble
       @errors
     end
 
+    # Builds a fresh, unsubmitted form for `ctx` using the form's declared field
+    # defaults. This does not parse or read the request body.
+    def self.fresh(ctx : Crumble::Server::HandlerContext) : self
+      new(ctx)
+    end
+
+    # Builds a fresh, unsubmitted form for the same context as this form.
+    def fresh : self
+      self.class.fresh(ctx)
+    end
+
     def self.from_www_form(ctx : Crumble::Server::HandlerContext, www_form : ::String) : self
       from_www_form(ctx, ::URI::Params.parse(www_form))
     end

--- a/src/form.cr
+++ b/src/form.cr
@@ -53,15 +53,11 @@ module Crumble
       @errors
     end
 
-    # Builds a fresh, unsubmitted form for `ctx` using the form's declared field
-    # defaults. This does not parse or read the request body.
-    def self.fresh(ctx : Crumble::Server::HandlerContext) : self
-      new(ctx)
-    end
-
-    # Builds a fresh, unsubmitted form for the same context as this form.
+    # Builds a fresh, unsubmitted form for the same context as this form using
+    # the form's declared field defaults. This does not parse or read the
+    # request body.
     def fresh : self
-      self.class.fresh(ctx)
+      self.class.new(ctx)
     end
 
     def self.from_www_form(ctx : Crumble::Server::HandlerContext, www_form : ::String) : self


### PR DESCRIPTION
## Summary
- Add documented `Crumble::Form.fresh(ctx)` and instance `#fresh` APIs for creating unsubmitted forms with declared defaults.
- Cover default values, transformed field rendering, same-context reset behavior, and request body preservation in specs.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/crystal-cache-cr137 crystal spec`