### PR TITLE
Add missing Open Graph meta tag methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ class InvitePage < Crumble::Page
 end
 ```
 
+Supported Open Graph methods include `og_title`, `og_type`, `og_url`, `og_description`, `og_determiner`, `og_locale`, `og_locale_alternate`, `og_site_name`, `og_audio`, `og_audio_secure_url`, `og_audio_type`, `og_image`, `og_image_url`, `og_image_secure_url`, `og_image_type`, `og_image_width`, `og_image_height`, `og_image_alt`, `og_video`, `og_video_secure_url`, `og_video_type`, `og_video_width`, `og_video_height`, and `og_video_alt`.
+
 ### Server & Routing
 
 - `Crumble::Server.start` boots an `HTTP::Server` with logging and optional OpenTelemetry tracing (`CRUMBLE_HOST` + `--port` flag control the bind address).

--- a/spec/open_graph_spec.cr
+++ b/spec/open_graph_spec.cr
@@ -16,12 +16,48 @@ module Crumble::OpenGraphSpec
       "Short description"
     end
 
+    def og_audio : String?
+      "https://example.com/theme.mp3"
+    end
+
+    def og_audio_secure_url : String?
+      "https://secure.example.com/theme.mp3"
+    end
+
+    def og_audio_type : String?
+      "audio/mpeg"
+    end
+
     def meta_description : String?
       "Join the room and chat in real time."
     end
 
+    def og_determiner : String?
+      "the"
+    end
+
     def og_image : String?
       "https://example.com/preview.png"
+    end
+
+    def og_image_url : String?
+      "https://example.com/preview.png"
+    end
+
+    def og_image_secure_url : String?
+      "https://secure.example.com/preview.png"
+    end
+
+    def og_image_type : String?
+      "image/png"
+    end
+
+    def og_image_width : String?
+      "1200"
+    end
+
+    def og_image_height : String?
+      "630"
     end
 
     def og_image_alt : String?
@@ -36,8 +72,40 @@ module Crumble::OpenGraphSpec
       "website"
     end
 
+    def og_locale : String?
+      "en_US"
+    end
+
+    def og_locale_alternate : Array(String)?
+      ["de_DE", "fr_FR"]
+    end
+
     def og_site_name : String?
       "Example"
+    end
+
+    def og_video : String?
+      "https://example.com/trailer.mp4"
+    end
+
+    def og_video_secure_url : String?
+      "https://secure.example.com/trailer.mp4"
+    end
+
+    def og_video_type : String?
+      "video/mp4"
+    end
+
+    def og_video_width : String?
+      "1280"
+    end
+
+    def og_video_height : String?
+      "720"
+    end
+
+    def og_video_alt : String?
+      "A short product trailer"
     end
 
     def twitter_card : String?
@@ -81,11 +149,29 @@ describe "OpenGraph meta tags" do
     res.should contain("<meta name=\"description\" content=\"Join the room and chat in real time.\">")
     res.should contain("<meta property=\"og:title\" content=\"Invite title\">")
     res.should contain("<meta property=\"og:description\" content=\"Short description\">")
+    res.should contain("<meta property=\"og:audio\" content=\"https://example.com/theme.mp3\">")
+    res.should contain("<meta property=\"og:audio:secure_url\" content=\"https://secure.example.com/theme.mp3\">")
+    res.should contain("<meta property=\"og:audio:type\" content=\"audio/mpeg\">")
+    res.should contain("<meta property=\"og:determiner\" content=\"the\">")
     res.should contain("<meta property=\"og:image\" content=\"https://example.com/preview.png\">")
+    res.should contain("<meta property=\"og:image:url\" content=\"https://example.com/preview.png\">")
+    res.should contain("<meta property=\"og:image:secure_url\" content=\"https://secure.example.com/preview.png\">")
+    res.should contain("<meta property=\"og:image:type\" content=\"image/png\">")
+    res.should contain("<meta property=\"og:image:width\" content=\"1200\">")
+    res.should contain("<meta property=\"og:image:height\" content=\"630\">")
     res.should contain("<meta property=\"og:image:alt\" content=\"Two people chatting in a web app\">")
     res.should contain("<meta property=\"og:url\" content=\"https://example.com/invite\">")
     res.should contain("<meta property=\"og:type\" content=\"website\">")
+    res.should contain("<meta property=\"og:locale\" content=\"en_US\">")
+    res.should contain("<meta property=\"og:locale:alternate\" content=\"de_DE\">")
+    res.should contain("<meta property=\"og:locale:alternate\" content=\"fr_FR\">")
     res.should contain("<meta property=\"og:site_name\" content=\"Example\">")
+    res.should contain("<meta property=\"og:video\" content=\"https://example.com/trailer.mp4\">")
+    res.should contain("<meta property=\"og:video:secure_url\" content=\"https://secure.example.com/trailer.mp4\">")
+    res.should contain("<meta property=\"og:video:type\" content=\"video/mp4\">")
+    res.should contain("<meta property=\"og:video:width\" content=\"1280\">")
+    res.should contain("<meta property=\"og:video:height\" content=\"720\">")
+    res.should contain("<meta property=\"og:video:alt\" content=\"A short product trailer\">")
     res.should contain("<meta name=\"twitter:card\" content=\"summary_large_image\">")
     res.should contain("<meta name=\"twitter:title\" content=\"Invite title\">")
     res.should contain("<meta name=\"twitter:description\" content=\"Short description\">")

--- a/src/ext/to_html/layout.cr
+++ b/src/ext/to_html/layout.cr
@@ -31,8 +31,44 @@ module ToHtml
           meta property: "og:description", content: description
         end
 
+        if audio = handler.og_audio
+          meta property: "og:audio", content: audio
+        end
+
+        if audio_secure_url = handler.og_audio_secure_url
+          meta property: "og:audio:secure_url", content: audio_secure_url
+        end
+
+        if audio_type = handler.og_audio_type
+          meta property: "og:audio:type", content: audio_type
+        end
+
+        if determiner = handler.og_determiner
+          meta property: "og:determiner", content: determiner
+        end
+
         if image = handler.og_image
           meta property: "og:image", content: image
+        end
+
+        if image_url = handler.og_image_url
+          meta property: "og:image:url", content: image_url
+        end
+
+        if image_secure_url = handler.og_image_secure_url
+          meta property: "og:image:secure_url", content: image_secure_url
+        end
+
+        if image_type = handler.og_image_type
+          meta property: "og:image:type", content: image_type
+        end
+
+        if image_width = handler.og_image_width
+          meta property: "og:image:width", content: image_width
+        end
+
+        if image_height = handler.og_image_height
+          meta property: "og:image:height", content: image_height
         end
 
         if image_alt = handler.og_image_alt
@@ -47,8 +83,42 @@ module ToHtml
           meta property: "og:type", content: type
         end
 
+        if locale = handler.og_locale
+          meta property: "og:locale", content: locale
+        end
+
+        if locale_alternate = handler.og_locale_alternate
+          locale_alternate.each do |locale|
+            meta property: "og:locale:alternate", content: locale
+          end
+        end
+
         if site_name = handler.og_site_name
           meta property: "og:site_name", content: site_name
+        end
+
+        if video = handler.og_video
+          meta property: "og:video", content: video
+        end
+
+        if video_secure_url = handler.og_video_secure_url
+          meta property: "og:video:secure_url", content: video_secure_url
+        end
+
+        if video_type = handler.og_video_type
+          meta property: "og:video:type", content: video_type
+        end
+
+        if video_width = handler.og_video_width
+          meta property: "og:video:width", content: video_width
+        end
+
+        if video_height = handler.og_video_height
+          meta property: "og:video:height", content: video_height
+        end
+
+        if video_alt = handler.og_video_alt
+          meta property: "og:video:alt", content: video_alt
         end
 
         if card = handler.twitter_card

--- a/src/server/view_handler.cr
+++ b/src/server/view_handler.cr
@@ -20,11 +20,47 @@ module Crumble::Server
       nil
     end
 
+    def og_audio : String?
+      nil
+    end
+
+    def og_audio_secure_url : String?
+      nil
+    end
+
+    def og_audio_type : String?
+      nil
+    end
+
+    def og_determiner : String?
+      nil
+    end
+
     def meta_description : String?
       nil
     end
 
     def og_image : String?
+      nil
+    end
+
+    def og_image_url : String?
+      nil
+    end
+
+    def og_image_secure_url : String?
+      nil
+    end
+
+    def og_image_type : String?
+      nil
+    end
+
+    def og_image_width : String?
+      nil
+    end
+
+    def og_image_height : String?
       nil
     end
 
@@ -40,7 +76,39 @@ module Crumble::Server
       nil
     end
 
+    def og_locale : String?
+      nil
+    end
+
+    def og_locale_alternate : Array(String)?
+      nil
+    end
+
     def og_site_name : String?
+      nil
+    end
+
+    def og_video : String?
+      nil
+    end
+
+    def og_video_secure_url : String?
+      nil
+    end
+
+    def og_video_type : String?
+      nil
+    end
+
+    def og_video_width : String?
+      nil
+    end
+
+    def og_video_height : String?
+      nil
+    end
+
+    def og_video_alt : String?
       nil
     end
 


### PR DESCRIPTION
## Summary
- Add missing protocol-level Open Graph methods to the view handler interface.
- Render audio, determiner, locale, image structured, and video structured meta tags in `ToHtml::Layout`.
- Document supported Open Graph methods and expand specs.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/crystal-cache- crystal spec spec/open_graph_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/crystal-cache- crystal spec`