### PR TITLE
Defer session storage until first access

### DIFF
--- a/spec/server/request_context_spec.cr
+++ b/spec/server/request_context_spec.cr
@@ -7,7 +7,9 @@ describe Crumble::Server::RequestContext do
       request_context = Crumble::Server::TestRequestContext.new(session_store: store)
 
       cookie = request_context.response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME]
-      store.has_key?(Crumble::Server::SessionKey.new(UUID.new(cookie.value))).should be_false
+      session_id = Crumble::Server::SessionKey.new(UUID.new(cookie.value))
+      request_context.session_id.should eq(session_id)
+      store.has_key?(session_id).should be_false
     end
 
     it "replaces an invalid session cookie without storing a session" do

--- a/spec/server/request_context_spec.cr
+++ b/spec/server/request_context_spec.cr
@@ -1,6 +1,27 @@
 require "../spec_helper"
 
 describe Crumble::Server::RequestContext do
+  describe "#initialize" do
+    it "sets a session cookie without storing a session when the request has no session cookie" do
+      store = Crumble::Server::MemorySessionStore.new
+      request_context = Crumble::Server::TestRequestContext.new(session_store: store)
+
+      cookie = request_context.response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME]
+      store.has_key?(Crumble::Server::SessionKey.new(UUID.new(cookie.value))).should be_false
+    end
+
+    it "replaces an invalid session cookie without storing a session" do
+      original_request = HTTP::Request.new("GET", "/dummy", nil, nil)
+      original_request.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME] = "not-a-uuid"
+      original_response = HTTP::Server::Response.new(IO::Memory.new)
+      original_context = HTTP::Server::Context.new(original_request, original_response)
+      Crumble::Server::RequestContext.new(original_context)
+
+      cookie = original_response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME]
+      cookie.value.should_not eq("not-a-uuid")
+    end
+  end
+
   describe "#session" do
     context "when the request has a cookie with a session key" do
       context "when a session with the key exists" do
@@ -8,10 +29,10 @@ describe Crumble::Server::RequestContext do
           existing_session_key = Crumble::Server::SessionKey.generate
 
           original_request = HTTP::Request.new("POST", "/dummy", nil, nil)
+          original_request.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME] = existing_session_key.to_s
           original_response = HTTP::Server::Response.new(IO::Memory.new)
           original_context = HTTP::Server::Context.new(original_request, original_response)
           request_context = Crumble::Server::RequestContext.new(original_context)
-          original_request.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME] = existing_session_key.to_s
           existing_session = Crumble::Server::Session.new(existing_session_key)
           Crumble::Server::RequestContext.session_store.set(existing_session)
 
@@ -22,18 +43,32 @@ describe Crumble::Server::RequestContext do
       end
 
       context "when no session with the key exists in the store" do
-        it "returns a decorator with a new session with a new key" do
+        it "returns a decorator with a new session using the request key" do
           existing_session_key = Crumble::Server::SessionKey.generate
 
           original_request = HTTP::Request.new("POST", "/dummy", nil, nil)
+          original_request.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME] = existing_session_key.to_s
           original_response = HTTP::Server::Response.new(IO::Memory.new)
           original_context = HTTP::Server::Context.new(original_request, original_response)
           request_context = Crumble::Server::RequestContext.new(original_context)
-          original_request.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME] = existing_session_key.to_s
 
-          request_context.session.id.should_not eq(existing_session_key)
-          original_response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME].path.should eq("/")
+          request_context.session.id.should eq(existing_session_key)
+          Crumble::Server::RequestContext.session_store.has_key?(existing_session_key).should be_true
+          original_response.cookies.has_key?(Crumble::Server::RequestContext::SESSION_COOKIE_NAME).should be_false
         end
+      end
+    end
+
+    context "when the request has no session cookie" do
+      it "stores the generated session on first access" do
+        store = Crumble::Server::MemorySessionStore.new
+        request_context = Crumble::Server::TestRequestContext.new(session_store: store)
+        cookie = request_context.response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME]
+        key = Crumble::Server::SessionKey.new(UUID.new(cookie.value))
+
+        store.has_key?(key).should be_false
+        request_context.session.id.should eq(key)
+        store.has_key?(key).should be_true
       end
     end
   end

--- a/spec/test_request_context.cr
+++ b/spec/test_request_context.cr
@@ -9,6 +9,7 @@ class Crumble::Server::TestRequestContext < Crumble::Server::RequestContext
     response = TestResponse.new(response_io)
     @original_context = HTTP::Server::Context.new(request, response)
     @session_store = session_store || MemorySessionStore.new
+    ensure_session_key
   end
 
   def session_store

--- a/src/server/request_context.cr
+++ b/src/server/request_context.cr
@@ -5,8 +5,11 @@ class Crumble::Server::RequestContext
   SESSION_COOKIE_NAME = "_crumble_session"
 
   @@session_store : SessionStore?
+  @session_id : SessionKey?
 
-  getter session_id : SessionKey?
+  getter session_id : SessionKey do
+    ensure_session_key
+  end
   getter original_context : HTTP::Server::Context
 
   delegate request, response, to: original_context

--- a/src/server/request_context.cr
+++ b/src/server/request_context.cr
@@ -51,25 +51,29 @@ class Crumble::Server::RequestContext
     end
   end
 
-  private def ensure_session_key
-    return @session_key.not_nil! if @session_key
-
-    if request.cookies.has_key?(SESSION_COOKIE_NAME)
-      begin
-        @session_key = SessionKey.new(UUID.new(request.cookies[SESSION_COOKIE_NAME].value))
-      rescue ArgumentError
-        # Bad client cookies should not break requests that never touch sessions.
-        set_new_session_key_cookie
-      end
-    else
-      set_new_session_key_cookie
+  private def ensure_session_key : SessionKey
+    if session_key = @session_key
+      return session_key
     end
 
-    @session_key.not_nil!
+    session_key = if cookie = request.cookies[SESSION_COOKIE_NAME]?
+                    if uuid = UUID.parse?(cookie.value)
+                      SessionKey.new(uuid)
+                    else
+                      # Bad client cookies should not break requests that never touch sessions.
+                      set_new_session_key_cookie
+                    end
+                  else
+                    set_new_session_key_cookie
+                  end
+
+    @session_key = session_key
+    session_key
   end
 
-  private def set_new_session_key_cookie
-    @session_key = SessionKey.generate
-    response.cookies << HTTP::Cookie.new(name: SESSION_COOKIE_NAME, value: @session_key.not_nil!.to_s, path: "/", max_age: session_cookie_max_age)
+  private def set_new_session_key_cookie : SessionKey
+    session_key = SessionKey.generate
+    response.cookies << HTTP::Cookie.new(name: SESSION_COOKIE_NAME, value: session_key.to_s, path: "/", max_age: session_cookie_max_age)
+    session_key
   end
 end

--- a/src/server/request_context.cr
+++ b/src/server/request_context.cr
@@ -5,12 +5,14 @@ class Crumble::Server::RequestContext
   SESSION_COOKIE_NAME = "_crumble_session"
 
   @@session_store : SessionStore?
+  @session_key : SessionKey?
 
   getter original_context : HTTP::Server::Context
 
   delegate request, response, to: original_context
 
   def initialize(@original_context)
+    ensure_session_key
   end
 
   def self.session_store
@@ -39,24 +41,35 @@ class Crumble::Server::RequestContext
   end
 
   private def load_session
-    if request.cookies.has_key?(SESSION_COOKIE_NAME)
-      key = SessionKey.new(UUID.new(request.cookies[SESSION_COOKIE_NAME].value))
-      if session_store.has_key?(key)
-        session_store[key]
-      else
-        # session does not exist anymore, drop the key and generate a new one
-        new_session
-      end
+    key = ensure_session_key
+    if session_store.has_key?(key)
+      session_store[key]
     else
-      new_session
+      session = Session.new(key)
+      session_store.set(session)
+      session
     end
   end
 
-  private def new_session
-    new_key = SessionKey.generate
-    s = Session.new(new_key)
-    response.cookies << HTTP::Cookie.new(name: SESSION_COOKIE_NAME, value: new_key.to_s, path: "/", max_age: session_cookie_max_age)
-    session_store.set(s)
-    s
+  private def ensure_session_key
+    return @session_key.not_nil! if @session_key
+
+    if request.cookies.has_key?(SESSION_COOKIE_NAME)
+      begin
+        @session_key = SessionKey.new(UUID.new(request.cookies[SESSION_COOKIE_NAME].value))
+      rescue ArgumentError
+        # Bad client cookies should not break requests that never touch sessions.
+        set_new_session_key_cookie
+      end
+    else
+      set_new_session_key_cookie
+    end
+
+    @session_key.not_nil!
+  end
+
+  private def set_new_session_key_cookie
+    @session_key = SessionKey.generate
+    response.cookies << HTTP::Cookie.new(name: SESSION_COOKIE_NAME, value: @session_key.not_nil!.to_s, path: "/", max_age: session_cookie_max_age)
   end
 end

--- a/src/server/request_context.cr
+++ b/src/server/request_context.cr
@@ -5,8 +5,8 @@ class Crumble::Server::RequestContext
   SESSION_COOKIE_NAME = "_crumble_session"
 
   @@session_store : SessionStore?
-  @session_key : SessionKey?
 
+  getter session_id : SessionKey?
   getter original_context : HTTP::Server::Context
 
   delegate request, response, to: original_context
@@ -52,7 +52,7 @@ class Crumble::Server::RequestContext
   end
 
   private def ensure_session_key : SessionKey
-    if session_key = @session_key
+    if session_key = @session_id
       return session_key
     end
 
@@ -67,7 +67,7 @@ class Crumble::Server::RequestContext
                     set_new_session_key_cookie
                   end
 
-    @session_key = session_key
+    @session_id = session_key
     session_key
   end
 


### PR DESCRIPTION
## Summary
- Generate and send a session cookie without immediately writing a session to storage
- Materialize missing sessions only when `ctx.session` is accessed
- Preserve valid client-provided session IDs and replace malformed cookie values
- Add request context specs for lazy storage behavior

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/crystal-cache- crystal spec`