### PR TITLE
Add secure defaults for session cookies

### DIFF
--- a/spec/server/request_context_spec.cr
+++ b/spec/server/request_context_spec.cr
@@ -1,5 +1,19 @@
 require "../spec_helper"
 
+private class CustomSessionCookieRequestContext < Crumble::Server::TestRequestContext
+  def session_cookie_http_only
+    false
+  end
+
+  def session_cookie_same_site
+    :strict
+  end
+
+  def session_cookie_secure
+    true
+  end
+end
+
 describe Crumble::Server::RequestContext do
   describe "#initialize" do
     it "sets a session cookie without storing a session when the request has no session cookie" do
@@ -21,6 +35,28 @@ describe Crumble::Server::RequestContext do
 
       cookie = original_response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME]
       cookie.value.should_not eq("not-a-uuid")
+    end
+
+    it "sets default security flags on new session cookies" do
+      request_context = Crumble::Server::TestRequestContext.new
+      cookie = request_context.response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME]
+
+      cookie.http_only.should be_true
+      cookie.samesite.should eq(HTTP::Cookie::SameSite::Lax)
+      {% if flag?(:release) %}
+        cookie.secure.should be_true
+      {% else %}
+        cookie.secure.should be_false
+      {% end %}
+    end
+
+    it "allows session cookie security flags to be overridden" do
+      request_context = CustomSessionCookieRequestContext.new
+      cookie = request_context.response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME]
+
+      cookie.http_only.should be_false
+      cookie.samesite.should eq(HTTP::Cookie::SameSite::Strict)
+      cookie.secure.should be_true
     end
   end
 

--- a/src/cli/templates/request_context.cr
+++ b/src/cli/templates/request_context.cr
@@ -15,6 +15,20 @@ module Crumble
       #   365.days
       # end
 
+      # def session_cookie_http_only
+      #   true
+      # end
+
+      # def session_cookie_same_site
+      #   :lax
+      # end
+
+      # Release builds default this to true. Override in development if you need
+      # cookies to be set over plain HTTP.
+      # def session_cookie_secure
+      #   false
+      # end
+
       # Add any methods you want to access on the `ctx` object in resources or views
     end
   end

--- a/src/server/request_context.cr
+++ b/src/server/request_context.cr
@@ -43,6 +43,25 @@ class Crumble::Server::RequestContext
     nil
   end
 
+  # Override this method to allow JavaScript access to the session cookie
+  def session_cookie_http_only
+    true
+  end
+
+  # Override this method to change the session cookie SameSite policy
+  def session_cookie_same_site
+    :lax
+  end
+
+  # Override this method to allow session cookies over plain HTTP
+  def session_cookie_secure
+    {% if flag?(:release) %}
+      true
+    {% else %}
+      false
+    {% end %}
+  end
+
   private def load_session
     key = ensure_session_key
     if session_store.has_key?(key)
@@ -74,9 +93,31 @@ class Crumble::Server::RequestContext
     session_key
   end
 
+  private def session_cookie_samesite
+    case same_site = session_cookie_same_site
+    when nil
+      nil
+    when HTTP::Cookie::SameSite
+      same_site
+    when Symbol
+      case same_site
+      when :lax
+        HTTP::Cookie::SameSite::Lax
+      when :strict
+        HTTP::Cookie::SameSite::Strict
+      when :none
+        HTTP::Cookie::SameSite::None
+      else
+        raise ArgumentError.new("Unsupported session cookie SameSite value: #{same_site.inspect}")
+      end
+    else
+      raise ArgumentError.new("Unsupported session cookie SameSite value: #{same_site.inspect}")
+    end
+  end
+
   private def set_new_session_key_cookie : SessionKey
     session_key = SessionKey.generate
-    response.cookies << HTTP::Cookie.new(name: SESSION_COOKIE_NAME, value: session_key.to_s, path: "/", max_age: session_cookie_max_age)
+    response.cookies << HTTP::Cookie.new(name: SESSION_COOKIE_NAME, value: session_key.to_s, path: "/", max_age: session_cookie_max_age, http_only: session_cookie_http_only, samesite: session_cookie_samesite, secure: session_cookie_secure)
     session_key
   end
 end


### PR DESCRIPTION
## Summary
- Add overridable session cookie settings for HttpOnly, SameSite, and Secure
- Apply those settings when creating new session cookies
- Document the new override hooks in the generated request context template
- Add specs for default cookie security flags and custom overrides

## Tests
- `crystal spec spec/server/request_context_spec.cr`
- `crystal spec`