### PR TITLE
Expose session lifecycle hooks for consent-aware extensions

### DIFF
--- a/spec/server/request_context_spec.cr
+++ b/spec/server/request_context_spec.cr
@@ -1,6 +1,10 @@
 require "../spec_helper"
 
 private class CustomSessionCookieRequestContext < Crumble::Server::TestRequestContext
+  def session_cookie_max_age
+    2.hours
+  end
+
   def session_cookie_http_only
     false
   end
@@ -11,6 +15,22 @@ private class CustomSessionCookieRequestContext < Crumble::Server::TestRequestCo
 
   def session_cookie_secure
     true
+  end
+end
+
+private class BrowserScopedNewSessionCookieRequestContext < CustomSessionCookieRequestContext
+  def new_session_cookie_max_age
+    nil
+  end
+end
+
+private class BrowserScopedReplacementCookieRequestContext < Crumble::Server::RequestContext
+  def session_cookie_max_age
+    2.hours
+  end
+
+  def new_session_cookie_max_age
+    nil
   end
 end
 
@@ -57,6 +77,69 @@ describe Crumble::Server::RequestContext do
       cookie.http_only.should be_false
       cookie.samesite.should eq(HTTP::Cookie::SameSite::Strict)
       cookie.secure.should be_true
+    end
+
+    it "uses the configured session lifetime for new cookies by default" do
+      request_context = CustomSessionCookieRequestContext.new
+
+      request_context.response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME].max_age.should eq(2.hours)
+    end
+
+    it "allows only new and replacement cookie lifetimes to be overridden" do
+      request_context = BrowserScopedNewSessionCookieRequestContext.new
+
+      request_context.response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME].max_age.should be_nil
+
+      original_request = HTTP::Request.new("GET", "/dummy", nil, nil)
+      original_request.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME] = "not-a-uuid"
+      original_response = HTTP::Server::Response.new(IO::Memory.new)
+      context = HTTP::Server::Context.new(original_request, original_response)
+      BrowserScopedReplacementCookieRequestContext.new(context)
+
+      original_response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME].max_age.should be_nil
+    end
+  end
+
+  describe "#stored_session?" do
+    it "returns false without storing or caching a newly generated session" do
+      store = Crumble::Server::MemorySessionStore.new
+      request_context = Crumble::Server::TestRequestContext.new(session_store: store)
+
+      request_context.stored_session?.should be_false
+      store.has_key?(request_context.session_id).should be_false
+    end
+
+    it "returns true when the current session ID exists in the store" do
+      store = Crumble::Server::MemorySessionStore.new
+      request_context = Crumble::Server::TestRequestContext.new(session_store: store)
+      store.set(Crumble::Server::Session.new(request_context.session_id))
+
+      request_context.stored_session?.should be_true
+    end
+  end
+
+  describe "#refresh_session_cookie" do
+    it "reissues the same ID with the configured lifetime and attributes" do
+      request_context = BrowserScopedNewSessionCookieRequestContext.new
+      session_id = request_context.session_id
+
+      request_context.refresh_session_cookie
+      cookie = request_context.response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME]
+
+      cookie.value.should eq(session_id.to_s)
+      cookie.path.should eq("/")
+      cookie.max_age.should eq(2.hours)
+      cookie.http_only.should be_false
+      cookie.samesite.should eq(HTTP::Cookie::SameSite::Strict)
+      cookie.secure.should be_true
+    end
+
+    it "accepts an explicit lifetime" do
+      request_context = BrowserScopedNewSessionCookieRequestContext.new
+
+      request_context.refresh_session_cookie(30.minutes)
+
+      request_context.response.cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME].max_age.should eq(30.minutes)
     end
   end
 

--- a/src/server/request_context.cr
+++ b/src/server/request_context.cr
@@ -37,10 +37,24 @@ class Crumble::Server::RequestContext
     @session ||= SessionDecorator.new(session_store, load_session)
   end
 
+  # Returns whether the current session ID is already present without loading or creating a session.
+  def stored_session? : Bool
+    session_store.has_key?(session_id)
+  end
+
   # Override this method to change the session cookie lifetime
-  # TODO: Think about how to properly test this
   def session_cookie_max_age
     nil
+  end
+
+  # Override this method to change the lifetime of newly issued session cookies only
+  def new_session_cookie_max_age
+    session_cookie_max_age
+  end
+
+  # Reissue the current session cookie, retaining its ID and configured attributes
+  def refresh_session_cookie(max_age = session_cookie_max_age) : Nil
+    write_session_cookie(session_id, max_age)
   end
 
   # Override this method to allow JavaScript access to the session cookie
@@ -64,7 +78,7 @@ class Crumble::Server::RequestContext
 
   private def load_session
     key = ensure_session_key
-    if session_store.has_key?(key)
+    if stored_session?
       session_store[key]
     else
       session = Session.new(key)
@@ -117,7 +131,11 @@ class Crumble::Server::RequestContext
 
   private def set_new_session_key_cookie : SessionKey
     session_key = SessionKey.generate
-    response.cookies << HTTP::Cookie.new(name: SESSION_COOKIE_NAME, value: session_key.to_s, path: "/", max_age: session_cookie_max_age, http_only: session_cookie_http_only, samesite: session_cookie_samesite, secure: session_cookie_secure)
+    write_session_cookie(session_key, new_session_cookie_max_age)
     session_key
+  end
+
+  private def write_session_cookie(session_key, max_age) : Nil
+    response.cookies << HTTP::Cookie.new(name: SESSION_COOKIE_NAME, value: session_key.to_s, path: "/", max_age: max_age, http_only: session_cookie_http_only, samesite: session_cookie_samesite, secure: session_cookie_secure)
   end
 end


### PR DESCRIPTION
## Summary

- Add a non-creating `stored_session?` query.
- Add an overridable lifetime hook for new and replacement cookies.
- Add `refresh_session_cookie` for reissuing the current session ID.
- Centralize cookie construction while preserving all configured attributes.
- Add focused coverage for lifecycle hooks, refresh behavior, and invalid cookies.

## Testing

- `crystal spec --error-trace`
- 126 examples, 0 failures