### PR TITLE
Create file session storage directories automatically

### DIFF
--- a/spec/server/file_session_store_spec.cr
+++ b/spec/server/file_session_store_spec.cr
@@ -7,10 +7,22 @@ describe Crumble::Server::FileSessionStore do
   end
 
   after_each do
-    FileUtils.rm_r("spec/tmp")
+    FileUtils.rm_rf("spec/tmp")
   end
 
-  it "saves a session and retrieves it again" do
+  it "creates a missing directory and saves a session with a supplied ID" do
+    session_id = Crumble::Server::SessionKey.generate
+    store = Crumble::Server::FileSessionStore.new("spec/tmp/sessions")
+    Dir.exists?("spec/tmp/sessions").should be_true
+
+    session = Crumble::Server::Session.new(session_id)
+    store.set(session)
+
+    store.has_key?(session_id).should be_true
+    store[session_id].id.should eq(session_id)
+  end
+
+  it "saves and retrieves a new session in an existing directory" do
     store = Crumble::Server::FileSessionStore.new("spec/tmp")
     session = Crumble::Server::Session.new
     store.set(session)

--- a/src/server/file_session_store.cr
+++ b/src/server/file_session_store.cr
@@ -1,4 +1,5 @@
 require "./session_store"
+require "file_utils"
 
 class Crumble::Server::FileSessionStore
   include SessionStore
@@ -7,6 +8,7 @@ class Crumble::Server::FileSessionStore
 
   def initialize(folder : String)
     @folder = Path.new(folder).normalize.to_native
+    FileUtils.mkdir_p(@folder)
   end
 
   def has_key?(key : SessionKey) : Bool


### PR DESCRIPTION
## Summary

- Create the configured file session directory during store initialization
- Preserve existing directories and session files
- Cover supplied and generated session IDs with missing and existing directories

## Testing

- `crystal spec` — 127 examples, 0 failures