### PR TITLE
Use Docker automatically for development watching

### DIFF
--- a/spec/watch_script_spec.cr
+++ b/spec/watch_script_spec.cr
@@ -1,0 +1,28 @@
+require "./spec_helper"
+
+describe "watch.sh" do
+  shared_script = File.read(Path[__DIR__, "..", "src", "watch.sh"])
+  generated_script = File.read(Path[__DIR__, "..", "src", "cli", "templates", "watch.sh"])
+
+  it "uses Docker when its daemon and a Dockerfile are available" do
+    shared_script.should contain(%(if [ -f "Dockerfile" ] && command -v docker > /dev/null 2>&1 && docker info > /dev/null 2>&1))
+    shared_script.should contain("docker build")
+    shared_script.should contain("docker run")
+    shared_script.should contain(%(-w Dockerfile))
+    shared_script.should contain(%(if [ "$PORT" != "0" ]))
+  end
+
+  it "retains the local Crystal build fallback" do
+    shared_script.should contain("crystal build --error-trace")
+    shared_script.should contain(%(watchexec -r -w "./bin"))
+  end
+
+  it "runs from the generated project's directory" do
+    generated_script.should contain(%(cd "$SCRIPT_DIR" || exit 1))
+  end
+
+  it "has valid shell syntax" do
+    Process.run("sh", ["-n", Path[__DIR__, "..", "src", "watch.sh"].to_s]).success?.should be_true
+    Process.run("sh", ["-n", Path[__DIR__, "..", "src", "cli", "templates", "watch.sh"].to_s]).success?.should be_true
+  end
+end

--- a/src/cli/templates/watch.sh
+++ b/src/cli/templates/watch.sh
@@ -9,4 +9,5 @@ if [ -f "$SCRIPT_DIR/.env" ]; then
   set +a
 fi
 
+cd "$SCRIPT_DIR" || exit 1
 exec "$SCRIPT_DIR/lib/crumble/src/watch.sh" "__CRUMBLE_NAME__" "__CRUMBLE_PORT__"

--- a/src/watch.sh
+++ b/src/watch.sh
@@ -5,12 +5,41 @@ PORT=$2
 SRC_FILENAME="src/$PROJ_FILENAME.cr"
 BIN_FILENAME="bin/$PROJ_FILENAME"
 
-watchexec -r -w src -w lib -e cr --no-vcs-ignore "crystal build --error-trace $SRC_FILENAME -o $BIN_FILENAME" &
-COMPILE_PID=$!
-
 export DATABASE_URL="${DATABASE_URL:-sqlite3://./data.db}"
 export ORMA_CONTINUOUS_MIGRATION="${ORMA_CONTINUOUS_MIGRATION:-1}"
 export LOG_LEVEL="${LOG_LEVEL:-trace}"
+
+if [ -f "Dockerfile" ] && command -v docker > /dev/null 2>&1 && docker info > /dev/null 2>&1; then
+  IMAGE_NAME="$PROJ_FILENAME-development"
+  CONTAINER_NAME="$PROJ_FILENAME-development"
+  PUBLISH_PORT=""
+  if [ "$PORT" != "0" ]; then
+    PUBLISH_PORT="-p '$PORT:$PORT'"
+  fi
+
+  cleanup() {
+    echo "Stopping child processes..."
+    kill "$WATCH_PID" 2> /dev/null
+    wait "$WATCH_PID" 2> /dev/null
+    docker rm -f "$CONTAINER_NAME" > /dev/null 2>&1
+    exit
+  }
+
+  trap cleanup SIGINT SIGTERM
+
+  # Removing the previous container before each run also cleans up containers
+  # left behind when watchexec stops the foreground Docker client on a rebuild.
+  watchexec -r -w src -w lib -w shard.yml -w shard.lock -w Dockerfile --no-vcs-ignore "docker build -t '$IMAGE_NAME' . && (docker rm -f '$CONTAINER_NAME' > /dev/null 2>&1 || true) && docker run --rm --name '$CONTAINER_NAME' -e DATABASE_URL -e ORMA_CONTINUOUS_MIGRATION -e LOG_LEVEL $PUBLISH_PORT '$IMAGE_NAME' -p '$PORT'" &
+  WATCH_PID=$!
+
+  echo "Press Ctrl+C to stop"
+
+  wait "$WATCH_PID"
+  exit
+fi
+
+watchexec -r -w src -w lib -e cr --no-vcs-ignore "crystal build --error-trace $SRC_FILENAME -o $BIN_FILENAME" &
+COMPILE_PID=$!
 
 # The bin watcher starts before the first compile completes, so skip the initial
 # run until the compiler has produced a binary to execute.


### PR DESCRIPTION
## Summary

- detect an available Docker daemon when a Dockerfile exists
- rebuild and restart the development container when project files change
- preserve the native Crystal watcher as a fallback
- run generated watchers from the project directory
- handle dynamically assigned ports without invalid Docker mappings

## Testing

- `crystal tool format --check src spec`
- `crystal spec` — 131 examples, 0 failures