### PR TITLE
Forward positional arguments from request forms

### DIFF
--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -69,6 +69,15 @@ class Crumble::FormSpec
     end
   end
 
+  class ContextForm < Crumble::Form
+    getter parent : String
+    field name : String
+
+    def initialize(ctx : Crumble::Server::HandlerContext, submitted : Bool, @parent : String, **values)
+      super(ctx, submitted, **values)
+    end
+  end
+
   class DefaultValueForm < Crumble::Form
     field access_token : String = default_access_token, type: :hidden
     field name : String = "  Default name  " do
@@ -482,6 +491,15 @@ class Crumble::FormSpec
   end
 
   describe ".from_request" do
+    it "forwards extra positional arguments to the form initializer" do
+      ctx = test_handler_context(method: "POST", headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"}, body: "name=Bob")
+      form = ContextForm.from_request(ctx, "parent-record")
+
+      form.name.should eq("Bob")
+      form.parent.should eq("parent-record")
+      form.submitted?.should be_true
+    end
+
     it "retains url-encoded behavior" do
       ctx = test_handler_context(method: "POST", headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"}, body: "name=+Bob+")
       TransformForm.from_request(ctx).name.should eq("Bob")

--- a/src/form.cr
+++ b/src/form.cr
@@ -64,11 +64,11 @@ module Crumble
       self.class.new(ctx)
     end
 
-    def self.from_www_form(ctx : Crumble::Server::HandlerContext, www_form : ::String) : self
-      from_www_form(ctx, ::URI::Params.parse(www_form))
+    def self.from_www_form(ctx : Crumble::Server::HandlerContext, www_form : ::String, *args) : self
+      from_www_form(ctx, ::URI::Params.parse(www_form), *args)
     end
 
-    def self.from_www_form(ctx : Crumble::Server::HandlerContext, params : ::URI::Params) : self
+    def self.from_www_form(ctx : Crumble::Server::HandlerContext, params : ::URI::Params, *args) : self
       {% begin %}
         {% for ivar in @type.instance_vars.select { |iv| iv.annotation(Field) } %}
           {% if ivar.annotation(Field)[:type] == :file %}
@@ -78,7 +78,7 @@ module Crumble
           {% end %}
         {% end %}
 
-        new(ctx, true,
+        new(ctx, true, *args,
           {% for ivar in @type.instance_vars.select { |iv| iv.annotation(Field) } %}
             {{ivar.name.id}}: %field{ivar.name},
           {% end %}
@@ -88,10 +88,10 @@ module Crumble
 
     # Parses the request body according to Content-Type. Multipart file bodies
     # are streamed to request-owned temporary files instead of being buffered.
-    def self.from_request(ctx : Crumble::Server::HandlerContext) : self
+    def self.from_request(ctx : Crumble::Server::HandlerContext, *args) : self
       content_type = ctx.request.headers["Content-Type"]?.try(&.downcase)
       if content_type.try(&.starts_with?("application/x-www-form-urlencoded"))
-        return from_www_form(ctx, ctx.request.body.try(&.gets_to_end) || "")
+        return from_www_form(ctx, ctx.request.body.try(&.gets_to_end) || "", *args)
       end
       unless content_type.try(&.starts_with?("multipart/form-data"))
         raise ParseError.new("Unsupported form Content-Type: #{content_type || "missing"}")
@@ -122,7 +122,7 @@ module Crumble
             %field{ivar.name} = {{ivar.type}}.from_www_form(params, {{ivar.name.stringify}})
           {% end %}
         {% end %}
-        %form = new(ctx, true,
+        %form = new(ctx, true, *args,
           {% for ivar in @type.instance_vars.select { |iv| iv.annotation(Field) } %}
             {{ivar.name.id}}: %field{ivar.name},
           {% end %}


### PR DESCRIPTION
## Summary

- Accept additional positional arguments in `Form.from_request`
- Forward them to subclass initializers for URL-encoded and multipart forms
- Add coverage for forms requiring additional construction context

## Testing

- `crystal spec spec/form_spec.cr`
- `crystal spec`